### PR TITLE
feat: add a cargo fmt check to CI to enforce style

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,6 +10,6 @@ jobs:
     container: rust:${{ matrix.rust-version }}
     steps:
       - uses: actions/checkout@v1
-      - run: cargo fmt --all -- --check
       - run: cargo build --release
       - run: cargo test
+      - run: cargo fmt --all -- --check


### PR DESCRIPTION
This causes the CI to fail if `cargo fmt` is not run by the contributor.