### PR TITLE
Create Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,15 @@
+# Docker files
+Dockerfile
+.dockerignore
+
+# Git files
+.git
+.github
+.gitignore
+LICENSE
+README.md
+
+# Cargo files
+**/*.rs.bk
+/target/
+Cargo.lock

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+FROM rust:slim
+
+RUN apt-get update && apt-get install -y \
+    build-essential autoconf automake libtool m4 \
+    ffmpeg \
+    youtube-dl \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR "/parrot"
+
+# Cache cargo build dependencies by creating a dummy source
+RUN mkdir src
+RUN echo "fn main() {}" > src/main.rs
+COPY Cargo.toml ./
+RUN cargo build --release
+
+COPY ./ ./
+RUN cargo build --release
+
+CMD ["cargo", "run", "--release"]


### PR DESCRIPTION
Closes #32, #12.

Adds Dockerfile to create a Parrot Docker image.

Slim version of Rust image was chosen because the alpine one has musl instead of glibc, and cross-compiling Opus gets somewhat complicated.