### PR TITLE
Fix Docker image build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ RUN apt-get update && apt-get install -y \
     build-essential autoconf automake libtool m4 \
     ffmpeg \
     youtube-dl \
+    libssl-dev pkg-config \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR "/parrot"


### PR DESCRIPTION
Fixes #34.

Like the error message suggests, the machine needs to have `libssl-dev` installed for OpenSSL support, and `pkg-config` for being able to find the library's location.