### PR TITLE
README.md refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ docker run -d --env-file .env ghcr.io/aquelemiguel/parrot:latest
 
 ## Development
 
+Make sure you've installed Rust. You can install Rust and its package manager, `cargo` by following the instructions on https://rustup.rs/.
 After installing the requirements below, simply run `cargo run`.
 
 ### Linux / MacOS
@@ -26,8 +27,6 @@ The command below installs a C compiler, GNU autotools, Opus (Discord's audio co
 apt install build-essential autoconf automake libtool m4 libopus-dev youtube-dl ffmpeg libssl-dev
 ```
 
-Furthermore, you must install Rust and its package manager, `cargo`. Follow the instructions on https://rustup.rs/.
-Don't forget to close and re-open your terminal after installing so the `PATH` is updated.
 ### Windows
 
 If you are using the MSVC toolchain, a prebuilt DLL for Opus is already provided for you.  


### PR DESCRIPTION
This is not another October-typical Readme refresh. As a new contributor, there were several things that I believe would have helped me get started more easily if they were present in the readme, especially the rust installation website: if not installed, Ubuntu just recommends using the not-so-up-to-date apt package.