### PR TITLE
fix: bot activity using configured prefix

### DIFF
--- a/src/events/serenity_handler.rs
+++ b/src/events/serenity_handler.rs
@@ -9,6 +9,8 @@ use serenity::{
 };
 use std::env;
 
+use crate::strings::DEFAULT_PREFIX;
+
 pub struct SerenityHandler;
 
 #[async_trait]
@@ -16,7 +18,7 @@ impl EventHandler for SerenityHandler {
     async fn ready(&self, ctx: Context, ready: Ready) {
         println!("🦜 {} is connected!", ready.user.name);
 
-        let prefix = env::var("PREFIX").unwrap_or_else(|_| "!".to_string());
+        let prefix = env::var("PREFIX").unwrap_or_else(|_| DEFAULT_PREFIX.to_string());
         let activity = Activity::listening(format!("{}play", prefix));
         ctx.set_activity(activity).await;
     }

--- a/src/events/serenity_handler.rs
+++ b/src/events/serenity_handler.rs
@@ -4,7 +4,7 @@ use serenity::{
     model::{
         gateway::Ready,
         id::GuildId,
-        prelude::{Activity, VoiceState},
+        prelude::{OnlineStatus, VoiceState},
     },
 };
 
@@ -14,7 +14,7 @@ pub struct SerenityHandler;
 impl EventHandler for SerenityHandler {
     async fn ready(&self, ctx: Context, ready: Ready) {
         println!("🦜 {} is connected!", ready.user.name);
-        ctx.set_activity(Activity::listening("!play")).await;
+        ctx.set_presence(None, OnlineStatus::Online).await;
     }
 
     async fn voice_state_update(

--- a/src/events/serenity_handler.rs
+++ b/src/events/serenity_handler.rs
@@ -4,9 +4,10 @@ use serenity::{
     model::{
         gateway::Ready,
         id::GuildId,
-        prelude::{OnlineStatus, VoiceState},
+        prelude::{Activity, VoiceState},
     },
 };
+use std::env;
 
 pub struct SerenityHandler;
 
@@ -14,7 +15,10 @@ pub struct SerenityHandler;
 impl EventHandler for SerenityHandler {
     async fn ready(&self, ctx: Context, ready: Ready) {
         println!("🦜 {} is connected!", ready.user.name);
-        ctx.set_presence(None, OnlineStatus::Online).await;
+
+        let prefix = env::var("PREFIX").unwrap_or_else(|_| "!".to_string());
+        let activity = Activity::listening(format!("{}play", prefix));
+        ctx.set_activity(activity).await;
     }
 
     async fn voice_state_update(

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,6 +27,7 @@ use parrot::{
         version::*,
     },
     events::serenity_handler::SerenityHandler,
+    strings::DEFAULT_PREFIX,
     utils::get_prefixes,
 };
 
@@ -63,7 +64,8 @@ async fn main() {
             c.dynamic_prefix(|ctx, msg| {
                 Box::pin(async move {
                     let prefixes = get_prefixes();
-                    let default_prefix = env::var("PREFIX").unwrap_or_else(|_| "!".to_string());
+                    let default_prefix =
+                        env::var("PREFIX").unwrap_or_else(|_| DEFAULT_PREFIX.to_string());
                     let guild_id = msg.guild(&ctx.cache).await.unwrap().id;
 
                     if let Some(serde_json::Value::String(guild_prefix)) =

--- a/src/strings.rs
+++ b/src/strings.rs
@@ -1,3 +1,5 @@
+pub const DEFAULT_PREFIX: &str = "!";
+
 pub const IDLE_ALERT: &str =
     "I've been idle for a while, so I'll leave for now to save resources.\nFeel free to summon me back any time!";
 

--- a/src/strings.rs
+++ b/src/strings.rs
@@ -1,4 +1,4 @@
-pub const DEFAULT_PREFIX: &str = "!";
+pub const DEFAULT_PREFIX: &str = "-";
 
 pub const IDLE_ALERT: &str =
     "I've been idle for a while, so I'll leave for now to save resources.\nFeel free to summon me back any time!";


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | -- |
| Dependencies | -- |
| Decisions | Bot prefix does not have to be the default one. Shows correct activity now.<br>Refactor magic constant being used as the default prefix and replace its usages. |