### PR TITLE
test: util module tests

### DIFF
--- a/src/tests/utils.rs
+++ b/src/tests/utils.rs
@@ -1,9 +1,76 @@
-use crate::utils;
+use serde_json::json;
+use serenity::model::prelude::User;
 use std::time::Duration;
+
+use crate::utils;
+
+#[test]
+fn test_get_full_username() {
+    let mut user = User::default();
+    user.name = "hello world".to_string();
+    user.discriminator = 1234;
+
+    let result = utils::get_full_username(&user);
+    assert_eq!(result, "hello world#1234");
+}
 
 #[test]
 fn test_get_human_readable_timestamp() {
+    let duration = Duration::from_secs(53);
+    let result = utils::get_human_readable_timestamp(duration);
+    assert_eq!(result, "00:53");
+
+    let duration = Duration::from_secs(3599);
+    let result = utils::get_human_readable_timestamp(duration);
+    assert_eq!(result, "59:59");
+
     let duration = Duration::from_secs(96548);
     let result = utils::get_human_readable_timestamp(duration);
-    assert_eq!(result, "26:49:08")
+    assert_eq!(result, "26:49:08");
+}
+
+#[test]
+fn test_merge_json() {
+    let mut result = json!({});
+
+    let json = json!({
+        "a": 1,
+        "b": true,
+        "c": "string",
+        "d": {
+            "f": "level1",
+            "g": {
+                "h": "level2"
+            }
+        }
+    });
+    utils::merge_json(&mut result, &json);
+    assert_eq!(result, json);
+
+    let json = json!({
+        "a": 5,
+        "d": {
+            "f": "level1",
+            "g": {
+                "h": "changed prop"
+            },
+            "i": "new prop"
+        }
+    });
+    utils::merge_json(&mut result, &json);
+    assert_eq!(
+        result,
+        json!({
+            "a": 5,
+            "b": true,
+            "c": "string",
+            "d": {
+                "f": "level1",
+                "g": {
+                    "h": "changed prop"
+                },
+                "i": "new prop"
+            }
+        })
+    );
 }

--- a/src/tests/utils.rs
+++ b/src/tests/utils.rs
@@ -2,7 +2,7 @@ use serde_json::json;
 use serenity::model::prelude::User;
 use std::time::Duration;
 
-use crate::utils;
+use crate::utils::{get_full_username, get_human_readable_timestamp, merge_json};
 
 #[test]
 fn test_get_full_username() {
@@ -10,22 +10,22 @@ fn test_get_full_username() {
     user.name = "hello world".to_string();
     user.discriminator = 1234;
 
-    let result = utils::get_full_username(&user);
+    let result = get_full_username(&user);
     assert_eq!(result, "hello world#1234");
 }
 
 #[test]
 fn test_get_human_readable_timestamp() {
     let duration = Duration::from_secs(53);
-    let result = utils::get_human_readable_timestamp(duration);
+    let result = get_human_readable_timestamp(duration);
     assert_eq!(result, "00:53");
 
     let duration = Duration::from_secs(3599);
-    let result = utils::get_human_readable_timestamp(duration);
+    let result = get_human_readable_timestamp(duration);
     assert_eq!(result, "59:59");
 
     let duration = Duration::from_secs(96548);
-    let result = utils::get_human_readable_timestamp(duration);
+    let result = get_human_readable_timestamp(duration);
     assert_eq!(result, "26:49:08");
 }
 
@@ -44,7 +44,7 @@ fn test_merge_json() {
             }
         }
     });
-    utils::merge_json(&mut result, &json);
+    merge_json(&mut result, &json);
     assert_eq!(result, json);
 
     let json = json!({
@@ -57,7 +57,7 @@ fn test_merge_json() {
             "i": "new prop"
         }
     });
-    utils::merge_json(&mut result, &json);
+    merge_json(&mut result, &json);
     assert_eq!(
         result,
         json!({

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -55,20 +55,20 @@ pub async fn send_added_to_queue_message(
     Ok(())
 }
 
+pub fn get_full_username(user: &User) -> String {
+    format!("{}#{:04}", user.name, user.discriminator)
+}
+
 pub fn get_human_readable_timestamp(duration: Duration) -> String {
     let seconds = duration.as_secs() % 60;
     let minutes = (duration.as_secs() / 60) % 60;
     let hours = duration.as_secs() / 3600;
 
     if hours < 1 {
-        format!("{}:{:02}", minutes, seconds)
+        format!("{:02}:{:02}", minutes, seconds)
     } else {
         format!("{}:{:02}:{:02}", hours, minutes, seconds)
     }
-}
-
-pub fn get_full_username(user: &User) -> String {
-    format!("{}#{:04}", user.name, user.discriminator)
 }
 
 pub fn get_prefixes() -> serde_json::Value {


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | -- |
| Dependencies | -- |
| Decisions | Add some tests to utils that are extremely easy to test, unlike commands.<br><br>Did not test messaging functions because they will be rewritten and moved out of this module soon.<br><br>Decided not to test `get_prefixes`. Doing so would require deleting existing `prefixes.json` files. This is ok in a testing environment like the CI tests, but for developers running tests locally, it would delete their `prefixes.json` which might be a problem. An option to solve this would be to give an `Option` (funny) to `get_prefixes` with the path to search for. For tests, we could redirect to a test path like `test/prefixes.json`. But that would then require, every time we call `get_prefixes` to do `get_prefixes(None)` for the default. This can be reconsidered later. |