### PR TITLE
fix: docker build

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,10 +8,6 @@ repository = "https://github.com/aquelemiguel/parrot"
 license = "MIT"
 keywords = ["discord", "music-bot", "rust"]
 
-[lib]
-name = "parrot"
-crate-type = ["rlib"]
-
 [dependencies]
 dotenv = "0.15"
 html2md = "0.2"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,5 @@
+# Build image
+# Necessary dependencies to build Parrot
 FROM rust:slim-bullseye as build
 
 RUN apt-get update && apt-get install -y \
@@ -9,21 +11,19 @@ WORKDIR "/parrot"
 # Cache cargo build dependencies by creating a dummy source
 RUN mkdir src
 RUN echo "fn main() {}" > src/main.rs
-RUN echo "" > src/lib.rs
 COPY Cargo.toml ./
 RUN cargo build --release
 
 COPY . .
 RUN cargo build --release
 
-# Our final base
+# Release image
+# Necessary dependencies to run Parrot
 FROM debian:bullseye-slim
 
 RUN apt-get update && apt-get install -y python3-pip ffmpeg
 RUN pip install -U yt-dlp
 
-# Copy the build artifact from the build stage
 COPY --from=build /parrot/target/release/parrot .
 
-# Run parrot's binary
 CMD ["./parrot"]

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,7 @@ use std::error::Error;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error>> {
-    dotenv::dotenv()?;
+    dotenv::dotenv().ok();
 
     let mut parrot = Client::default().await?;
     if let Err(why) = parrot.start().await {

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,7 @@ use std::error::Error;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error>> {
-    dotenv::dotenv().unwrap();
+    dotenv::dotenv()?;
 
     let mut parrot = Client::default().await?;
     if let Err(why) = parrot.start().await {


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | -- |
| Dependencies | -- |
| Decisions | Generated binary is not correct. `[lib]` annotation is not needed in `Cargo.toml` to keep using it as a library, so I just reverted. |