### PR TITLE
feat: Implement docker deployment fallback

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -53,7 +53,7 @@ jobs:
           username: ${{ secrets.SSH_USER }}
           key: ${{ secrets.SSH_KEY }}
           script_stop: true
-          script: echo "::set-output name=LAST_RUNNING_TAG::docker ps | grep 'v[[:digit:]]*.[[:digit:]]*.[[:digit:]]*' -ow"
+          script: echo ::set-output name=LAST_RUNNING_TAG::docker ps | grep 'v[[:digit:]]*.[[:digit:]]*.[[:digit:]]*' -ow
       - name: Remove Exited Containers
         uses: appleboy/ssh-action@master
         with:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -74,3 +74,11 @@ jobs:
           key: ${{ secrets.SSH_KEY }}
           script_stop: true
           script: docker run -d --pull "always" --env-file .env ghcr.io/${{ github.repository }}:${{ github.ref_name }}
+      - name: Check Status of New Image With Fallback Deployment
+        uses: appleboy/ssh-action@master
+        with:
+          host: ${{ secrets.SSH_HOST }}
+          username: ${{ secrets.SSH_USER }}
+          key: ${{ secrets.SSH_KEY }}
+          script_stop: true
+          script: if [ ! "$(docker ps | grep ghcr.io/${{ github.repository }}:${{ github.ref_name }})" ]; then docker run -d --env-file .env ghcr.io/${{ github.repository }}:${{ steps.previoustag.outputs.tag }};  fi

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -45,33 +45,6 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     steps:
-      - name: Get Previous Successfuly Run Tag
-        uses: appleboy/ssh-action@master
-        id: version
-        with:
-          host: ${{ secrets.SSH_HOST }}
-          username: ${{ secrets.SSH_USER }}
-          key: ${{ secrets.SSH_KEY }}
-          script_stop: true
-          script: echo "::set-output name=LAST_RUNNING_TAG::$(docker ps | grep 'v[[:digit:]]*.[[:digit:]]*.[[:digit:]]*' -ow)"
-      - name: Remove Exited Containers
-        uses: appleboy/ssh-action@master
-        with:
-          host: ${{ secrets.SSH_HOST }}
-          username: ${{ secrets.SSH_USER }}
-          key: ${{ secrets.SSH_KEY }}
-          script_stop: true
-          script: docker rm $(docker ps --filter status=exited -q)
-      - name: Kill All Docker Containers
-        uses: appleboy/ssh-action@master
-        with:
-          host: ${{ secrets.SSH_HOST }}
-          username: ${{ secrets.SSH_USER }}
-          key: ${{ secrets.SSH_KEY }}
-          script_stop: true
-          script: |
-            containers=$(docker ps -q)
-            if [ ! -z $containers ]; then docker kill $containers; fi
       - name: Deploy with New Image
         uses: appleboy/ssh-action@master
         with:
@@ -80,11 +53,19 @@ jobs:
           key: ${{ secrets.SSH_KEY }}
           script_stop: true
           script: docker run -d --pull "always" --env-file .env ghcr.io/${{ github.repository }}:${{ github.ref_name }}
-      - name: Check Status of New Image With Fallback Deployment
+      - name: Check New Image Status With Removal of Old Images
         uses: appleboy/ssh-action@master
         with:
           host: ${{ secrets.SSH_HOST }}
           username: ${{ secrets.SSH_USER }}
           key: ${{ secrets.SSH_KEY }}
           script_stop: true
-          script: if [ ! "$(docker ps | grep ghcr.io/${{ github.repository }}:${{ github.ref_name }})" ]; then docker run -d --env-file .env ghcr.io/${{ github.repository }}:${{ steps.version.outputs.LAST_RUNNING_TAG }};  fi
+          script: if [ "$(docker ps | grep ghcr.io/${{ github.repository }}:${{ github.ref_name }})" ]; then docker kill $(docker ps -aq | grep -v -E $(docker ps -aq --filter ancestor=ghcr.io/${{ github.repository }}:${{ github.ref_name }} | paste -sd "|" -));  fi
+      - name: Remove Exited Containers
+        uses: appleboy/ssh-action@master
+        with:
+          host: ${{ secrets.SSH_HOST }}
+          username: ${{ secrets.SSH_USER }}
+          key: ${{ secrets.SSH_KEY }}
+          script_stop: true
+          script: docker rm $(docker ps --filter status=exited -q)

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -53,7 +53,7 @@ jobs:
           username: ${{ secrets.SSH_USER }}
           key: ${{ secrets.SSH_KEY }}
           script_stop: true
-          script: echo ::set-output name=LAST_RUNNING_TAG::docker ps | grep 'v[[:digit:]]*.[[:digit:]]*.[[:digit:]]*' -ow
+          script: echo ::set-output name=LAST_RUNNING_TAG::$(docker ps | grep 'v[[:digit:]]*.[[:digit:]]*.[[:digit:]]*' -ow)
       - name: Remove Exited Containers
         uses: appleboy/ssh-action@master
         with:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -45,6 +45,9 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     steps:
+      - name: Get previous tag
+        id: previoustag
+        uses: "WyriHaximus/github-action-get-previous-tag@v1"
       - name: Kill All Docker Containers
         uses: appleboy/ssh-action@master
         with:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -48,6 +48,14 @@ jobs:
       - name: Get previous tag
         id: previoustag
         uses: "WyriHaximus/github-action-get-previous-tag@v1"
+      - name: Remove Exited Containers
+        uses: appleboy/ssh-action@master
+        with:
+          host: ${{ secrets.SSH_HOST }}
+          username: ${{ secrets.SSH_USER }}
+          key: ${{ secrets.SSH_KEY }}
+          script_stop: true
+          script: docker rm $(docker ps --filter status=exited -q)
       - name: Kill All Docker Containers
         uses: appleboy/ssh-action@master
         with:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -45,9 +45,15 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     steps:
-      - name: Get previous tag
-        id: previoustag
-        uses: "WyriHaximus/github-action-get-previous-tag@v1"
+      - name: Get Previous Successfuly Run Tag
+        uses: appleboy/ssh-action@master
+        id: version
+        with:
+          host: ${{ secrets.SSH_HOST }}
+          username: ${{ secrets.SSH_USER }}
+          key: ${{ secrets.SSH_KEY }}
+          script_stop: true
+          script: echo "::set-output name=LAST_RUNNING_TAG::docker ps | grep 'v[[:digit:]]*.[[:digit:]]*.[[:digit:]]*' -ow"
       - name: Remove Exited Containers
         uses: appleboy/ssh-action@master
         with:
@@ -81,4 +87,4 @@ jobs:
           username: ${{ secrets.SSH_USER }}
           key: ${{ secrets.SSH_KEY }}
           script_stop: true
-          script: if [ ! "$(docker ps | grep ghcr.io/${{ github.repository }}:${{ github.ref_name }})" ]; then docker run -d --env-file .env ghcr.io/${{ github.repository }}:${{ steps.previoustag.outputs.tag }};  fi
+          script: if [ ! "$(docker ps | grep ghcr.io/${{ github.repository }}:${{ github.ref_name }})" ]; then docker run -d --env-file .env ghcr.io/${{ github.repository }}:${{ steps.version.outputs.LAST_RUNNING_TAG }};  fi

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -53,7 +53,7 @@ jobs:
           username: ${{ secrets.SSH_USER }}
           key: ${{ secrets.SSH_KEY }}
           script_stop: true
-          script: echo ::set-output name=LAST_RUNNING_TAG::$(docker ps | grep 'v[[:digit:]]*.[[:digit:]]*.[[:digit:]]*' -ow)
+          script: echo "::set-output name=LAST_RUNNING_TAG::$(docker ps | grep 'v[[:digit:]]*.[[:digit:]]*.[[:digit:]]*' -ow)"
       - name: Remove Exited Containers
         uses: appleboy/ssh-action@master
         with:


### PR DESCRIPTION
As the title implies, this PR implements a Docker Deployment Fallback.

The need for this arose from the changes made by #77, which broke the docker deployment, however, a simple `docker run` would not reveal that. As such, I've implemented a check immediately after deployment that checks for the running container. If it is running it kills the old deployment, if not it proceeds to the next step which removes all exited containers.

A successful action can be observed here: https://github.com/aquelemiguel/parrot/runs/4756107077?check_suite_focus=true