### PR TITLE
feat: add docker prune to docker workflow

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -67,5 +67,11 @@ jobs:
           host: ${{ secrets.SSH_HOST }}
           username: ${{ secrets.SSH_USER }}
           key: ${{ secrets.SSH_KEY }}
-          script_stop: true
           script: docker rm $(docker ps --filter status=exited -q)
+      - name: Docker Prune
+        uses: appleboy/ssh-action@master
+        with:
+          host: ${{ secrets.SSH_HOST }}
+          username: ${{ secrets.SSH_USER }}
+          key: ${{ secrets.SSH_KEY }}
+          script: docker system prune -a -f


### PR DESCRIPTION
A workflow failed due to lack of space as we only have 10GB in our machine.  
A simple 🧹 `docker system prune -a -f` solved the problem and after the re-run of the workflow everything went well 🧹