### PR TITLE
fix: switched `docker ps` flag

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -60,7 +60,7 @@ jobs:
           username: ${{ secrets.SSH_USER }}
           key: ${{ secrets.SSH_KEY }}
           script_stop: true
-          script: if [ "$(docker ps | grep ghcr.io/${{ github.repository }}:${{ github.ref_name }})" ]; then docker kill $(docker ps -aq | grep -v -E $(docker ps -aq --filter ancestor=ghcr.io/${{ github.repository }}:${{ github.ref_name }} | paste -sd "|" -));  fi
+          script: if [ "$(docker ps | grep ghcr.io/${{ github.repository }}:${{ github.ref_name }})" ]; then docker kill $(docker ps -q | grep -v -E $(docker ps -aq --filter ancestor=ghcr.io/${{ github.repository }}:${{ github.ref_name }} | paste -sd "|" -));  fi
       - name: Remove Exited Containers
         uses: appleboy/ssh-action@master
         with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "parrot"
-version = "0.5.0"
+version = "1.0.1"
 authors = ["aquelemiguel"]
 edition = "2018"
 description = "A Discord music bot built in Rust"


### PR DESCRIPTION
The `-qa` flag was set before the addition of the step `Remove Exited Containers` aka:

>  `docker rm $(docker ps --filter status=exited -q)`

Right now we only need the current active container, we need to change to simply `-a`.