### PR TITLE
ci: Optimised CI workflows

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,48 @@
+name: Lint
+
+on: [push, pull_request]
+
+jobs:
+  clippy:
+    name: Clippy
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      - name: Install stable toolchain
+        id: toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          components: clippy
+          profile: minimal
+          override: true
+
+      - name: Cache
+        uses: Swatinem/rust-cache@v1
+
+      - name: Run clippy
+        uses: actions-rs/clippy-check@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+  rustfmt:
+    name: Format
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      - name: Install stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          components: rustfmt
+          profile: minimal
+          override: true
+
+      - name: Run cargo fmt
+        run: cargo fmt --all -- --check

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -27,6 +27,7 @@ jobs:
         uses: actions-rs/clippy-check@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          args: -- -D clippy::all
 
   rustfmt:
     name: Format

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,10 +33,10 @@ jobs:
         run: cargo clippy -- -D clippy::all
 
       - name: Build Release Binary
-        run: cargo build --release
+        run: cargo build
 
       - name: Run Unit Tests
         run: cargo test
 
       - name: Check minimal versions
-        run: cargo clean; cargo update -Z minimal-versions; cargo check
+        run: cargo clean; cargo update; cargo check

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,8 +32,11 @@ jobs:
       - name: Format Rust Code
         run: cargo fmt --all -- --check
 
-      - name: Lint Rust Code
-        run: cargo clippy -- -D clippy::all
+      - name: Run clippy
+        uses: actions-rs/clippy-check@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          args: --workspace --tests
 
       - name: Run Unit Tests
         run: cargo test

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,11 +17,28 @@ jobs:
       - name: Cache
         uses: Swatinem/rust-cache@v1
 
+      - name: Install stable toolchain
+        id: toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          components: clippy, rustfmt
+          profile: minimal
+          override: true
+
       - name: Build Binary
-        run: cargo build --release
+        run: cargo build
+
+      - name: Run cargo fmt
+        run: cargo fmt --all -- --check
+
+      - name: Run clippy
+        uses: actions-rs/clippy-check@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run Unit Tests
-        run: cargo test --release
+        run: cargo test
 
       - name: Check minimal versions
         run: cargo update

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,11 +1,10 @@
 name: Main Workflow
-on:
-  push:
-    branches: [main]
-  pull_request:
-    branches: [main]
+
+on: [push, pull_request]
+
 jobs:
   build:
+    name: Build
     strategy:
       matrix:
         rust-version: ["1.54", "1.55", "1.56", "1.57"]
@@ -15,18 +14,25 @@ jobs:
       - name: Repository Checkout
         uses: actions/checkout@v2
 
+      - name: Install toolchain
+        id: tc
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+          components: rustfmt, clippy
+
       - name: Format Rust Code
-        run: |
-          rustup component add rustfmt
-          cargo fmt --all -- --check
+        run: cargo fmt --all -- --check
 
       - name: Lint Rust Code
-        run: |
-          rustup component add clippy
-          cargo clippy -- -D clippy::all
+        run: cargo clippy -- -D clippy::all
 
       - name: Build Release Binary
         run: cargo build --release
 
       - name: Run Unit Tests
         run: cargo test
+
+      - name: Check minimal versions
+        run: cargo clean; cargo update -Z minimal-versions; cargo check

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,6 +20,7 @@ jobs:
         with:
           toolchain: stable
           override: true
+          profile: minimal
           components: rustfmt, clippy
 
       - name: Cache

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,10 +18,15 @@ jobs:
         uses: Swatinem/rust-cache@v1
 
       - name: Build Binary
-        run: cargo build
+        run: cargo build --locked
+
+      - name: Build Release Binary
+        if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/')
+        run: cargo build --release --locked
 
       - name: Run Unit Tests
         run: cargo test
 
-      - name: Check minimal versions
-        run: cargo update
+      - name: Run Release Unit Tests
+        if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/')
+        run: cargo test --release --locked

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,7 +27,7 @@ jobs:
         uses: Swatinem/rust-cache@v1
 
       - name: Build Binary
-        run: cargo build
+        run: cargo build --release
 
       - name: Format Rust Code
         run: cargo fmt --all -- --check

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,14 +26,14 @@ jobs:
       - name: Cache
         uses: Swatinem/rust-cache@v1
 
+      - name: Build Binary
+        run: cargo build
+
       - name: Format Rust Code
         run: cargo fmt --all -- --check
 
       - name: Lint Rust Code
         run: cargo clippy -- -D clippy::all
-
-      - name: Build Release Binary
-        run: cargo build
 
       - name: Run Unit Tests
         run: cargo test

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ jobs:
     name: Build
     strategy:
       matrix:
-        rust-version: ["1.54", "1.55", "1.56", "1.57"]
+        rust-version: ["1.55", "1.56", "1.57"]
     runs-on: ubuntu-latest
     container: rust:${{ matrix.rust-version }}
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,25 +17,8 @@ jobs:
       - name: Cache
         uses: Swatinem/rust-cache@v1
 
-      - name: Install stable toolchain
-        id: toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          components: clippy, rustfmt
-          profile: minimal
-          override: true
-
       - name: Build Binary
         run: cargo build
-
-      - name: Run cargo fmt
-        run: cargo fmt --all -- --check
-
-      - name: Run clippy
-        uses: actions-rs/clippy-check@v1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run Unit Tests
         run: cargo test

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,4 +42,4 @@ jobs:
         run: cargo test
 
       - name: Check minimal versions
-        run: cargo clean; cargo update; cargo check
+        run: cargo update; cargo check

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,6 +22,9 @@ jobs:
           override: true
           components: rustfmt, clippy
 
+      - name: Cache
+        uses: Swatinem/rust-cache@v1
+
       - name: Format Rust Code
         run: cargo fmt --all -- --check
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,31 +14,14 @@ jobs:
       - name: Repository Checkout
         uses: actions/checkout@v2
 
-      - name: Install toolchain
-        id: tc
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          override: true
-          profile: minimal
-          components: rustfmt, clippy
-
       - name: Cache
         uses: Swatinem/rust-cache@v1
 
       - name: Build Binary
-        run: cargo build
-
-      - name: Format Rust Code
-        run: cargo fmt --all -- --check
-
-      - name: Run clippy
-        uses: actions-rs/clippy-check@v1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+        run: cargo build --release
 
       - name: Run Unit Tests
-        run: cargo test
+        run: cargo test --release
 
       - name: Check minimal versions
         run: cargo update

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,10 +36,9 @@ jobs:
         uses: actions-rs/clippy-check@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          args: --workspace --tests
 
       - name: Run Unit Tests
         run: cargo test
 
       - name: Check minimal versions
-        run: cargo update; cargo check
+        run: cargo update

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,7 +27,7 @@ jobs:
         uses: Swatinem/rust-cache@v1
 
       - name: Build Binary
-        run: cargo build --release
+        run: cargo build
 
       - name: Format Rust Code
         run: cargo fmt --all -- --check


### PR DESCRIPTION
After some investigation on [Serenity](https://github.com/serenity-rs/serenity/blob/current/.github/workflows/ci.yml)'s and [Deno](https://github.com/denoland/deno/blob/main/.github/workflows/ci.ymla#L341)'s GitHub Actions, I've taken myself to improve our own Workflows to:
- Add Clippy feedback within the PR's file changes using [clippy-check](https://github.com/actions-rs/clippy-check).
![image](https://user-images.githubusercontent.com/19473034/150849762-3744785b-7dc6-4ca4-ad34-65df2755fa78.png)
- Separate Formatting and Linting into a separate workflow to take advantage of actions parallelism and reduce action time delta.
- Remove the unnecessary `--release` profile from normal day-to-day workflows, restricting it to builds in `main` and releases.
- Add build caching so that the action does not build from scratch on every step of the job.

In the end, this resulted in cutting build times by **50%**, which will result in an increased development speed.