### PR TITLE
docs: added MacOS build requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,11 +22,20 @@ docker run -d --env-file .env ghcr.io/aquelemiguel/parrot:latest
 Make sure you've installed Rust. You can install Rust and its package manager, `cargo` by following the instructions on https://rustup.rs/.
 After installing the requirements below, simply run `cargo run`.
 
-### Linux / MacOS
-The command below installs a C compiler, GNU autotools, Opus (Discord's audio codec), FFmpeg and the SSL library for development, as well as [yt-dlp](https://github.com/yt-dlp/yt-dlp) through Python's package manager, pip.
+### Linux/MacOS
+The commands below installs a C compiler, GNU autotools and FFmpeg, as well as [yt-dlp](https://github.com/yt-dlp/yt-dlp) through Python's package manager, pip.
+
+#### Linux
 
 ```shell
-apt install build-essential autoconf automake libtool m4 libopus-dev ffmpeg libssl-dev
+apt install build-essential autoconf automake libtool ffmpeg
+pip install -U yt-dlp
+```
+
+#### MacOS
+
+```shell
+brew install autoconf automake libtool ffmpeg
 pip install -U yt-dlp
 ```
 


### PR DESCRIPTION
Recently I got my hands on an Apple machine and the development tools were not, at all, on par with what was actually needed. 

Since the scripts for Linux and MacOS are still very similar, I've decided to not repeat the commands description and just separate the commands themselves.

PS: By cross-referencing information with the results of #114, I removed `libopus-dev` as well, as it seems that it comes built-in with `ffmpeg`, since in the Dockerfile this library was never present and everything still works. This assumption was double-confirmed by the following message on MacOS: 
![image](https://user-images.githubusercontent.com/19473034/150851952-d7bac3b0-c3f5-45d3-aa66-21b97f801f62.png)
