### PR TITLE
build: prune unused Docker dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,7 @@
 FROM rust:slim-bullseye as build
 
 RUN apt-get update && apt-get install -y \
-    build-essential autoconf automake libtool m4 \
-    libssl-dev pkg-config
+    build-essential autoconf automake libtool 
 
 WORKDIR "/parrot"
 


### PR DESCRIPTION
As a result of the recently opened #113, I decided to challenge the dependencies that were defined in the Dockerfile, and it seems that 3 of them could be removed (`m4 libssl-dev pkg-config`).

I've tested this with every Discord action that I could remember, and everything still worked without these dependencies.