### PR TITLE
feat: custom DJ Role for parrot commands

### DIFF
--- a/src/handlers/serenity.rs
+++ b/src/handlers/serenity.rs
@@ -105,6 +105,7 @@ impl SerenityHandler {
                     command
                         .name("np")
                         .description("Displays information about the current track")
+                        .default_permission(true)
                 })
                 .create_application_command(|command| {
                     command
@@ -139,7 +140,7 @@ impl SerenityHandler {
                         })
                 })
                 .create_application_command(|command| {
-                    command.name("queue").description("Shows the queue")
+                    command.name("queue").description("Shows the queue").default_permission(true)
                 })
                 .create_application_command(|command| {
                     command
@@ -204,6 +205,7 @@ impl SerenityHandler {
                     command
                         .name("version")
                         .description("Displays the current version")
+                        .default_permission(true)
                 })
         })
         .await

--- a/src/handlers/serenity.rs
+++ b/src/handlers/serenity.rs
@@ -261,8 +261,17 @@ impl SerenityHandler {
         let commands = self.create_commands(ctx).await;
         for guild in ready.guilds {
             let guild_id = guild.id();
-            let role = self.ensure_role(ctx, guild_id).await.unwrap();
-            self.apply_role(ctx, role, guild_id, &commands).await;
+
+            // ensures the role exists by creating it if not
+            // if it fails to create (e.g. no permissions)
+            // it does nothing but output a debug log
+            match self.ensure_role(ctx, guild_id).await {
+                Ok(role) => self.apply_role(ctx, role, guild_id, &commands).await,
+                Err(err) => println!(
+                    "Could not create '{}' role for guild {} because {:?}",
+                    PARROT_ROLE, guild_id, err
+                ),
+            };
         }
     }
 }

--- a/src/handlers/serenity.rs
+++ b/src/handlers/serenity.rs
@@ -22,7 +22,7 @@ use crate::commands::{
     remove::*, repeat::*, resume::*, seek::*, shuffle::*, skip::*, stop::*, summon::*, version::*,
 };
 
-const PARROT_ROLE: &str = "Parrot DJ";
+const ROLE: &str = "Parrot DJ";
 
 pub struct SerenityHandler;
 
@@ -212,12 +212,12 @@ impl SerenityHandler {
 
     async fn ensure_role(&self, ctx: &Context, guild: GuildId) -> Result<Role, SerenityError> {
         let roles = guild.roles(&ctx.http).await.unwrap();
-        let role = roles.iter().find(|(_, role)| role.name == PARROT_ROLE);
+        let role = roles.iter().find(|(_, role)| role.name == ROLE);
         match role {
             Some((_, role)) => Ok(role.to_owned()),
             None => {
                 guild
-                    .create_role(&ctx.http, |r| r.name(PARROT_ROLE).mentionable(true))
+                    .create_role(&ctx.http, |r| r.name(ROLE).mentionable(true))
                     .await
             }
         }
@@ -269,7 +269,7 @@ impl SerenityHandler {
                 Ok(role) => self.apply_role(ctx, role, guild_id, &commands).await,
                 Err(err) => println!(
                     "Could not create '{}' role for guild {} because {:?}",
-                    PARROT_ROLE, guild_id, err
+                    ROLE, guild_id, err
                 ),
             };
         }

--- a/src/handlers/serenity.rs
+++ b/src/handlers/serenity.rs
@@ -1,11 +1,16 @@
+use serenity::prelude::SerenityError;
 use serenity::{
     async_trait,
     client::{Context, EventHandler},
     model::{
         gateway::Ready,
+        guild::Role,
         id::GuildId,
         interactions::{
-            application_command::{ApplicationCommand, ApplicationCommandOptionType},
+            application_command::{
+                ApplicationCommand, ApplicationCommandInteraction, ApplicationCommandOptionType,
+                ApplicationCommandPermissionType,
+            },
             Interaction,
         },
         prelude::{Activity, VoiceState},
@@ -17,6 +22,8 @@ use crate::commands::{
     remove::*, repeat::*, resume::*, seek::*, shuffle::*, skip::*, stop::*, summon::*, version::*,
 };
 
+const PARROT_ROLE: &str = "Parrot DJ";
+
 pub struct SerenityHandler;
 
 #[async_trait]
@@ -24,38 +31,90 @@ impl EventHandler for SerenityHandler {
     async fn ready(&self, ctx: Context, ready: Ready) {
         println!("🦜 {} is connected!", ready.user.name);
 
+        // sets parrot activity status message to /play
         let activity = Activity::listening("/play");
         ctx.set_activity(activity).await;
 
+        // creates the global application commands
+        // and sets them with the correct permissions
+        self.set_commands(&ctx, ready).await;
+    }
+
+    async fn interaction_create(&self, ctx: Context, interaction: Interaction) {
+        if let Interaction::ApplicationCommand(mut command) = interaction {
+            self.run_command(&ctx, &mut command).await;
+        }
+    }
+
+    async fn voice_state_update(
+        &self,
+        ctx: Context,
+        guild: Option<GuildId>,
+        _old: Option<VoiceState>,
+        new: VoiceState,
+    ) {
+        self.self_deafen(&ctx, guild, new).await;
+    }
+}
+
+impl SerenityHandler {
+    async fn apply_role(
+        &self,
+        ctx: &Context,
+        role: Role,
+        guild: GuildId,
+        commands: &[ApplicationCommand],
+    ) {
+        for command in commands {
+            guild
+                .create_application_command_permission(&ctx.http, command.id, |p| {
+                    p.create_permission(|d| {
+                        d.kind(ApplicationCommandPermissionType::Role)
+                            .id(role.id.0)
+                            .permission(true)
+                    })
+                })
+                .await
+                .unwrap();
+        }
+    }
+
+    async fn create_commands(&self, ctx: &Context) -> Vec<ApplicationCommand> {
         ApplicationCommand::set_global_application_commands(&ctx.http, |commands| {
             commands
                 .create_application_command(|command| {
                     command
                         .name("autopause")
                         .description("Toggles whether to pause after a song ends")
+                        .default_permission(false)
                 })
                 .create_application_command(|command| {
                     command.name("clear").description("Clears the queue")
+                    .default_permission(false)
                 })
                 .create_application_command(|command| {
                     command
                         .name("leave")
                         .description("Leave the voice channel the bot is connected to")
+                        .default_permission(false)
                 })
                 .create_application_command(|command| {
                     command
                         .name("np")
                         .description("Displays information about the current track")
+                        .default_permission(false)
                 })
                 .create_application_command(|command| {
                     command
                         .name("pause")
                         .description("Pauses the current track")
+                        .default_permission(false)
                 })
                 .create_application_command(|command| {
                     command
                         .name("play")
                         .description("Adds a track to the queue")
+                        .default_permission(false)
                         .create_option(|option| {
                             option
                                 .name("query")
@@ -68,6 +127,7 @@ impl EventHandler for SerenityHandler {
                     command
                         .name("playtop")
                         .description("Places a track on the top of the queue")
+                        .default_permission(false)
                         .create_option(|option| {
                             option
                                 .name("query")
@@ -78,11 +138,13 @@ impl EventHandler for SerenityHandler {
                 })
                 .create_application_command(|command| {
                     command.name("queue").description("Shows the queue")
+                    .default_permission(false)
                 })
                 .create_application_command(|command| {
                     command
                         .name("remove")
                         .description("Removes a track from the queue")
+                        .default_permission(false)
                         .create_option(|option| {
                             option
                                 .name("index")
@@ -96,16 +158,19 @@ impl EventHandler for SerenityHandler {
                     command
                         .name("repeat")
                         .description("Toggles looping for the current track")
+                        .default_permission(false)
                 })
                 .create_application_command(|command| {
                     command
                         .name("resume")
                         .description("Resumes the current track")
+                        .default_permission(false)
                 })
                 .create_application_command(|command| {
                     command
                         .name("seek")
                         .description("Seeks current track to the given position")
+                        .default_permission(false)
                         .create_option(|option| {
                             option
                                 .name("timestamp")
@@ -116,69 +181,88 @@ impl EventHandler for SerenityHandler {
                 })
                 .create_application_command(|command| {
                     command.name("shuffle").description("Shuffles the queue")
+                    .default_permission(false)
                 })
                 .create_application_command(|command| {
                     command.name("skip").description("Skips the current track")
+                    .default_permission(false)
                 })
                 .create_application_command(|command| {
                     command
                         .name("stop")
                         .description("Stops the bot and clears the queue")
+                        .default_permission(false)
                 })
                 .create_application_command(|command| {
                     command
                         .name("summon")
                         .description("Summons the bot in your voice channel")
+                        .default_permission(false)
                 })
                 .create_application_command(|command| {
                     command
                         .name("version")
                         .description("Displays the current version")
+                        .default_permission(false)
                 })
         })
         .await
-        .unwrap();
+        .unwrap()
     }
 
-    async fn interaction_create(&self, ctx: Context, interaction: Interaction) {
-        if let Interaction::ApplicationCommand(mut command) = interaction {
-            match command.data.name.as_str() {
-                "autopause" => autopause(&ctx, &mut command).await,
-                "clear" => clear(&ctx, &mut command).await,
-                "leave" => leave(&ctx, &mut command).await,
-                "np" => now_playing(&ctx, &mut command).await,
-                "pause" => pause(&ctx, &mut command).await,
-                "play" => play(&ctx, &mut command).await,
-                "playtop" => playtop(&ctx, &mut command).await,
-                "queue" => queue(&ctx, &mut command).await,
-                "remove" => remove(&ctx, &mut command).await,
-                "repeat" => repeat(&ctx, &mut command).await,
-                "resume" => resume(&ctx, &mut command).await,
-                "seek" => seek(&ctx, &mut command).await,
-                "shuffle" => shuffle(&ctx, &mut command).await,
-                "skip" => skip(&ctx, &mut command).await,
-                "stop" => stop(&ctx, &mut command).await,
-                "summon" => summon(&ctx, &mut command, true).await,
-                "version" => version(&ctx, &mut command).await,
-                _ => unimplemented!(),
+    async fn ensure_role(&self, ctx: &Context, guild: GuildId) -> Result<Role, SerenityError> {
+        let roles = guild.roles(&ctx.http).await.unwrap();
+        let role = roles.iter().find(|(_, role)| role.name == PARROT_ROLE);
+        match role {
+            Some((_, role)) => Ok(role.to_owned()),
+            None => {
+                guild
+                    .create_role(&ctx.http, |r| r.name(PARROT_ROLE).mentionable(true))
+                    .await
             }
-            .unwrap();
         }
     }
 
-    async fn voice_state_update(
-        &self,
-        ctx: Context,
-        guild: Option<GuildId>,
-        _old: Option<VoiceState>,
-        new: VoiceState,
-    ) {
+    async fn run_command(&self, ctx: &Context, command: &mut ApplicationCommandInteraction) {
+        match command.data.name.as_str() {
+            "autopause" => autopause(ctx, command).await,
+            "clear" => clear(ctx, command).await,
+            "leave" => leave(ctx, command).await,
+            "np" => now_playing(ctx, command).await,
+            "pause" => pause(ctx, command).await,
+            "play" => play(ctx, command).await,
+            "playtop" => playtop(ctx, command).await,
+            "queue" => queue(ctx, command).await,
+            "remove" => remove(ctx, command).await,
+            "repeat" => repeat(ctx, command).await,
+            "resume" => resume(ctx, command).await,
+            "seek" => seek(ctx, command).await,
+            "shuffle" => shuffle(ctx, command).await,
+            "skip" => skip(ctx, command).await,
+            "stop" => stop(ctx, command).await,
+            "summon" => summon(ctx, command, true).await,
+            "version" => version(ctx, command).await,
+            _ => unimplemented!(),
+        }
+        .unwrap();
+    }
+
+    async fn self_deafen(&self, ctx: &Context, guild: Option<GuildId>, new: VoiceState) {
         if new.user_id == ctx.http.get_current_user().await.unwrap().id && !new.deaf {
             guild
                 .unwrap()
                 .edit_member(&ctx.http, new.user_id, |n| n.deafen(true))
                 .await
                 .unwrap();
+        }
+    }
+
+    async fn set_commands(&self, ctx: &Context, ready: Ready) {
+        let commands = self.create_commands(ctx).await;
+        for guild in ready.guilds {
+            let guild_id = guild.id();
+            let role = self.ensure_role(ctx, guild_id).await.unwrap();
+            self.apply_role(ctx, role, guild_id, &commands).await;
         }
     }
 }

--- a/src/handlers/serenity.rs
+++ b/src/handlers/serenity.rs
@@ -65,6 +65,9 @@ impl SerenityHandler {
         guild: GuildId,
         commands: &[ApplicationCommand],
     ) {
+        let commands = commands
+            .iter()
+            .filter(|command| !command.default_permission);
         for command in commands {
             guild
                 .create_application_command_permission(&ctx.http, command.id, |p| {
@@ -102,7 +105,6 @@ impl SerenityHandler {
                     command
                         .name("np")
                         .description("Displays information about the current track")
-                        .default_permission(false)
                 })
                 .create_application_command(|command| {
                     command
@@ -138,7 +140,6 @@ impl SerenityHandler {
                 })
                 .create_application_command(|command| {
                     command.name("queue").description("Shows the queue")
-                    .default_permission(false)
                 })
                 .create_application_command(|command| {
                     command
@@ -203,7 +204,6 @@ impl SerenityHandler {
                     command
                         .name("version")
                         .description("Displays the current version")
-                        .default_permission(false)
                 })
         })
         .await

--- a/src/handlers/serenity.rs
+++ b/src/handlers/serenity.rs
@@ -264,7 +264,7 @@ impl SerenityHandler {
 
     async fn set_commands(&self, ctx: &Context, ready: Ready) {
         let commands = self.create_commands(ctx).await;
-        let role_name = ready.user.name + " DJ";
+        let role_name = ready.user.name + "'s DJ";
         for guild in ready.guilds {
             let guild_id = guild.id();
 

--- a/src/handlers/serenity.rs
+++ b/src/handlers/serenity.rs
@@ -115,7 +115,7 @@ impl SerenityHandler {
                     command
                         .name("play")
                         .description("Adds a track to the queue")
-                        .default_permission(false)
+                        .default_permission(true)
                         .create_option(|option| {
                             option
                                 .name("query")
@@ -197,7 +197,7 @@ impl SerenityHandler {
                     command
                         .name("summon")
                         .description("Summons the bot in your voice channel")
-                        .default_permission(false)
+                        .default_permission(true)
                 })
                 .create_application_command(|command| {
                     command

--- a/src/handlers/serenity.rs
+++ b/src/handlers/serenity.rs
@@ -262,8 +262,8 @@ impl SerenityHandler {
         for guild in ready.guilds {
             let guild_id = guild.id();
 
-            // ensures the role exists by creating it if not
-            // if it fails to create (e.g. no permissions)
+            // ensures the role exists, creating it if does not
+            // if it fails to create the role (e.g. no permissions)
             // it does nothing but output a debug log
             match self.ensure_role(ctx, guild_id).await {
                 Ok(role) => self.apply_role(ctx, role, guild_id, &commands).await,


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | Closes https://github.com/aquelemiguel/parrot/issues/47 |
| Dependencies | `"Manage Roles"` permission is now required and Wiki should be updated after this merge. |
| Decisions | - Refactor code to make handlers smaller and call what they need.<br>- Set permissions for all guilds for all commands of the DJ Role.<br>- The DJ Role name can then be changed by the discord admins if they want, but I picked a default ("Parrot DJ").<br>- Parrot ensures the role exists by either using an already existing one or creating a new one.<br>- now playing, queue, play, summon and version are unrestrained |
| Animated GIF | ![dj-role-commands](https://user-images.githubusercontent.com/16060539/151027353-d4e931bd-14bb-4b56-8e77-00524e0d458d.gif) |