### PR TITLE
feat: play jump subcommand

### DIFF
--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -16,7 +16,7 @@ pub mod stop;
 pub mod summon;
 pub mod version;
 
-#[derive(Copy, Clone)]
+#[derive(Clone, Copy)]
 pub enum PlayMode {
     End,
     Next,
@@ -26,7 +26,7 @@ pub enum PlayMode {
     Jump,
 }
 
-#[derive(Copy, Clone)]
+#[derive(Clone, Copy)]
 pub enum QueryType {
     Keywords,
     VideoLink,

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -23,10 +23,12 @@ pub enum PlayMode {
     All,
     Reverse,
     Shuffle,
+    Jump,
 }
 
-pub enum EnqueueType {
-    Link,
-    Search,
-    Playlist,
+#[derive(Copy, Clone)]
+pub enum QueryType {
+    Keywords,
+    VideoLink,
+    PlaylistLink,
 }

--- a/src/commands/play.rs
+++ b/src/commands/play.rs
@@ -1,8 +1,11 @@
 use crate::{
-    commands::{summon::summon, EnqueueType, PlayMode},
+    commands::{summon::summon, PlayMode, QueryType},
     handlers::track_end::update_queue_messages,
     sources::youtube::YouTubeRestartable,
-    strings::{PLAY_PLAYLIST, PLAY_QUEUE, PLAY_TOP, SEARCHING, TRACK_DURATION, TRACK_TIME_TO_PLAY},
+    strings::{
+        PLAY_ALL_FAILED, PLAY_PLAYLIST, PLAY_QUEUE, PLAY_TOP, SEARCHING, TRACK_DURATION,
+        TRACK_TIME_TO_PLAY,
+    },
     utils::{
         create_now_playing_embed, create_response, edit_embed_response, edit_response,
         get_human_readable_timestamp,
@@ -40,6 +43,7 @@ pub async fn play(
         "reverse" => PlayMode::Reverse,
         "shuffle" => PlayMode::Shuffle,
         "end" => PlayMode::End,
+        "jump" => PlayMode::Jump,
         _ => PlayMode::End,
     };
 
@@ -53,20 +57,59 @@ pub async fn play(
     // needed because interactions must be replied within 3s and queueing takes longer
     create_response(&ctx.http, interaction, SEARCHING).await?;
 
-    let enqueue_type = match mode {
-        PlayMode::All | PlayMode::Reverse | PlayMode::Shuffle => EnqueueType::Playlist,
-        _ if url.contains("youtube.com/playlist?list=") => EnqueueType::Playlist,
-        _ if url.starts_with("http") => EnqueueType::Link,
-        _ => EnqueueType::Search,
+    let query_type = if url.contains("youtube.com/playlist?list=") {
+        QueryType::PlaylistLink
+    } else if url.starts_with("http") {
+        QueryType::VideoLink
+    } else {
+        QueryType::Keywords
     };
 
     let call = manager.get(guild_id).unwrap();
 
-    match enqueue_type {
-        EnqueueType::Link => enqueue_song(&call, url.to_string(), true, mode).await,
-        EnqueueType::Search => enqueue_song(&call, url.to_string(), false, mode).await,
-        EnqueueType::Playlist => enqueue_playlist(&call, url, mode).await,
-    };
+    match mode {
+        PlayMode::End => match query_type {
+            QueryType::Keywords | QueryType::VideoLink => {
+                enqueue_song(&call, url.to_string(), query_type).await;
+            }
+            QueryType::PlaylistLink => {
+                enqueue_playlist(&call, url, mode).await;
+            }
+        },
+        PlayMode::Next => match query_type {
+            QueryType::Keywords | QueryType::VideoLink => {
+                enqueue_song(&call, url.to_string(), query_type).await;
+                rotate_tracks(&call, 1).await;
+            }
+            QueryType::PlaylistLink => {
+                if let Some(playlist) = enqueue_playlist(&call, url, mode).await {
+                    rotate_tracks(&call, playlist.len()).await;
+                }
+            }
+        },
+        PlayMode::Jump => match query_type {
+            QueryType::Keywords | QueryType::VideoLink => {
+                enqueue_song(&call, url.to_string(), query_type).await;
+                rotate_tracks(&call, 1).await;
+                force_skip_top_track(&call).await;
+            }
+            QueryType::PlaylistLink => {
+                if let Some(playlist) = enqueue_playlist(&call, url, mode).await {
+                    rotate_tracks(&call, playlist.len()).await;
+                    force_skip_top_track(&call).await;
+                }
+            }
+        },
+        PlayMode::All | PlayMode::Reverse | PlayMode::Shuffle => match query_type {
+            QueryType::VideoLink | QueryType::PlaylistLink => {
+                enqueue_playlist(&call, url, mode).await;
+            }
+            _ => {
+                edit_response(&ctx.http, interaction, PLAY_ALL_FAILED).await?;
+                return Ok(());
+            }
+        },
+    }
 
     let handler = call.lock().await;
     let queue = handler.queue().current_queue();
@@ -75,20 +118,20 @@ pub async fn play(
     if queue.len() > 1 {
         let estimated_time = calculate_time_until_play(&queue, mode).await.unwrap();
 
-        match (enqueue_type, mode) {
-            (EnqueueType::Link | EnqueueType::Search, PlayMode::Next) => {
+        match (query_type, mode) {
+            (QueryType::VideoLink | QueryType::Keywords, PlayMode::Next) => {
                 let track = queue.get(1).unwrap();
                 let embed = create_queued_embed(PLAY_TOP, track, estimated_time).await;
 
                 edit_embed_response(&ctx.http, interaction, embed).await?;
             }
-            (EnqueueType::Link | EnqueueType::Search, PlayMode::End) => {
+            (QueryType::VideoLink | QueryType::Keywords, PlayMode::End) => {
                 let track = queue.last().unwrap();
                 let embed = create_queued_embed(PLAY_QUEUE, track, estimated_time).await;
 
                 edit_embed_response(&ctx.http, interaction, embed).await?;
             }
-            (EnqueueType::Playlist, _) => {
+            (QueryType::PlaylistLink, _) => {
                 edit_response(&ctx.http, interaction, PLAY_PLAYLIST).await?;
             }
             (_, _) => {}
@@ -102,6 +145,32 @@ pub async fn play(
 
     update_queue_messages(&ctx.http, &ctx.data, &call, guild_id).await;
     Ok(())
+}
+
+async fn rotate_tracks(call: &Arc<Mutex<Call>>, n: usize) {
+    let handler = call.lock().await;
+
+    if handler.queue().len() <= 2 {
+        return;
+    }
+
+    handler.queue().modify_queue(|queue| {
+        let mut not_playing = queue.split_off(1);
+        not_playing.rotate_right(n);
+        queue.append(&mut not_playing);
+    });
+}
+
+async fn force_skip_top_track(call: &Arc<Mutex<Call>>) {
+    let handler = call.lock().await;
+
+    // this is an odd sequence of commands to ensure the queue is properly updated
+    // apparently, skipping/stopping a track takes a little to remove it from the queue
+    // also, manually removing tracks doesn't trigger the next track to play
+    // so first, stop the top song, manually remove it and then resume playback
+    handler.queue().current().unwrap().stop().ok();
+    handler.queue().dequeue(0);
+    handler.queue().resume().ok();
 }
 
 async fn calculate_time_until_play(queue: &[TrackHandle], mode: PlayMode) -> Option<Duration> {
@@ -138,12 +207,18 @@ async fn calculate_time_until_play(queue: &[TrackHandle], mode: PlayMode) -> Opt
     }
 }
 
-async fn enqueue_playlist(call: &Arc<Mutex<Call>>, uri: &str, mode: PlayMode) {
+async fn enqueue_playlist(
+    call: &Arc<Mutex<Call>>,
+    uri: &str,
+    mode: PlayMode,
+) -> Option<Vec<String>> {
     if let Some(urls) = YouTubeRestartable::ytdl_playlist(uri, mode).await {
-        for url in urls {
-            enqueue_song(call, url.to_string(), true, mode).await;
+        for url in urls.iter() {
+            enqueue_song(call, url.to_string(), QueryType::VideoLink).await;
         }
+        return Some(urls);
     }
+    None
 }
 
 async fn create_queued_embed(
@@ -178,11 +253,11 @@ async fn create_queued_embed(
     embed
 }
 
-async fn enqueue_song(call: &Arc<Mutex<Call>>, query: String, is_url: bool, mode: PlayMode) {
-    let source_return = if is_url {
-        YouTubeRestartable::ytdl(query, true).await
-    } else {
-        YouTubeRestartable::ytdl_search(query, true).await
+async fn enqueue_song(call: &Arc<Mutex<Call>>, query: String, query_type: QueryType) {
+    let source_return = match query_type {
+        QueryType::VideoLink => YouTubeRestartable::ytdl(query, true).await,
+        QueryType::Keywords => YouTubeRestartable::ytdl_search(query, true).await,
+        QueryType::PlaylistLink => unreachable!(),
     };
 
     // safeguard against ytdl dying on a private / deleted video and killing the playlist
@@ -193,18 +268,4 @@ async fn enqueue_song(call: &Arc<Mutex<Call>>, query: String, is_url: bool, mode
 
     let mut handler = call.lock().await;
     handler.enqueue_source(source.into());
-    let queue_snapshot = handler.queue().current_queue();
-    drop(handler);
-
-    if let PlayMode::Next = mode {
-        if queue_snapshot.len() > 2 {
-            let handler = call.lock().await;
-
-            handler.queue().modify_queue(|queue| {
-                let mut not_playing = queue.split_off(1);
-                not_playing.rotate_right(1);
-                queue.append(&mut not_playing);
-            });
-        }
-    }
 }

--- a/src/handlers/serenity.rs
+++ b/src/handlers/serenity.rs
@@ -155,6 +155,18 @@ impl SerenityHandler {
                         })
                         .create_option(|option| {
                             option
+                                .name("jump")
+                                .description("Instantly plays a track, skipping the current one")
+                                .kind(ApplicationCommandOptionType::SubCommand)
+                                .create_sub_option(|option| {
+                                    option.name("query")
+                                    .description("The media to play")
+                                    .kind(ApplicationCommandOptionType::String)
+                                    .required(true)
+                                })
+                        })
+                        .create_option(|option| {
+                            option
                                 .name("all")
                                 .description("Add all tracks if the URL refers to a video and a playlist")
                                 .kind(ApplicationCommandOptionType::SubCommand)

--- a/src/sources/youtube.rs
+++ b/src/sources/youtube.rs
@@ -53,7 +53,12 @@ impl YouTubeRestartable {
 
             let lines = reader.lines().flatten().map(|line| {
                 let entry: Value = serde_json::from_str(&line).unwrap();
-                entry.get("url").unwrap().as_str().unwrap().to_string()
+                entry
+                    .get("webpage_url")
+                    .unwrap()
+                    .as_str()
+                    .unwrap()
+                    .to_string()
             });
 
             Some(lines.collect())

--- a/src/strings.rs
+++ b/src/strings.rs
@@ -17,6 +17,8 @@ pub const LOOP_DISABLED: &str = "🔁 Disabled loop!";
 pub const LOOP_ENABLED: &str = "🔁 Enabled loop!";
 pub const NOTHING_IS_PLAYING: &str = "🔈 Nothing is playing!";
 pub const PAUSED: &str = "⏸️ Paused!";
+pub const PLAY_ALL_FAILED: &str =
+    "⚠️ Cannot fetch playlist via keywords! Try passing this command an URL.";
 pub const PLAY_PLAYLIST: &str = "📃 Added playlist to queue!";
 pub const PLAY_QUEUE: &str = "📃 Added to queue!";
 pub const PLAY_TOP: &str = "📃 Added to top!";


### PR DESCRIPTION
* Implements `/play jump` subcommand as described by #51.
* Adds previously missing behaviours like front-pushing a playlist.
* Refactors the play logic to be much more readable.