### PR TITLE
fix: clippy for rust `1.59.0`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,12 +7,18 @@ jobs:
     name: Build
     strategy:
       matrix:
-        rust-version: ["1.55", "1.56", "1.57", "1.58", "1.59"]
+        rust-version: ["1.54", "stable"]
     runs-on: ubuntu-latest
-    container: rust:${{ matrix.rust-version }}
     steps:
       - name: Repository Checkout
         uses: actions/checkout@v2
+
+      - name: Install Toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: ${{ matrix.rust-version }}
+          profile: minimal
+          override: true
 
       - name: Cache
         uses: Swatinem/rust-cache@v1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ jobs:
     name: Build
     strategy:
       matrix:
-        rust-version: ["1.55", "1.56", "1.57"]
+        rust-version: ["1.55", "1.56", "1.57", "1.58", "1.59"]
     runs-on: ubuntu-latest
     container: rust:${{ matrix.rust-version }}
     steps:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -836,7 +836,7 @@ dependencies = [
 
 [[package]]
 name = "parrot"
-version = "1.2.1"
+version = "1.3.0"
 dependencies = [
  "dotenv",
  "rand 0.8.4",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "parrot"
-version = "1.2.1"
+version = "1.3.0"
 authors = ["aquelemiguel"]
 edition = "2018"
 description = "A Discord music bot built in Rust"

--- a/src/commands/seek.rs
+++ b/src/commands/seek.rs
@@ -25,12 +25,10 @@ pub async fn seek(
     let (minutes, seconds) = (
         units_iter
             .next()
-            .map(|token| token.parse::<u64>().ok())
-            .flatten(),
+            .and_then(|token| token.parse::<u64>().ok()),
         units_iter
             .next()
-            .map(|token| token.parse::<u64>().ok())
-            .flatten(),
+            .and_then(|token| token.parse::<u64>().ok()),
     );
 
     if minutes.is_none() || seconds.is_none() {

--- a/src/sources/youtube.rs
+++ b/src/sources/youtube.rs
@@ -174,7 +174,7 @@ async fn _ytdl_metadata(uri: &str) -> SongbirdResult<Metadata> {
     let end = (&o_vec)
         .iter()
         .position(|el| *el == NEWLINE_BYTE)
-        .unwrap_or_else(|| o_vec.len());
+        .unwrap_or(o_vec.len());
 
     let value = serde_json::from_slice(&o_vec[..end]).map_err(|err| SongbirdError::Json {
         error: err,


### PR DESCRIPTION
Currently the [CI's clippy is failing](https://github.com/aquelemiguel/parrot/runs/5327167853) due to the release of [Rust `1.59.0`](https://blog.rust-lang.org/2022/02/24/Rust-1.59.0.html). This PR fixes those errors.

- [x] Moved from **container specific** builds to **toolchain specific** builds to allow for a permanent build process with rust's `stable` toolchain. This also follows the build process that is also used in Serenity.
- [x] Started testing only for the **MRSV** (Minimum supported rust version, which was tested to be 1.54.0 due to some nightly features that were only available from this version forward) and **Stable**.
- [x] Applied `1.59.0` clippy fixes.
- [x] Bumped `version` to `1.3.0`.