### PR TITLE
fix: unresponsiveness with long songs

### DIFF
--- a/src/sources/youtube.rs
+++ b/src/sources/youtube.rs
@@ -101,6 +101,7 @@ where
 async fn ytdl(uri: &str) -> Result<(Child, Metadata), SongbirdError> {
     let ytdl_args = [
         "-j",            // print JSON information for video for metadata
+        "-q",            // don't print progress logs (this messes with -o -)
         "--no-simulate", // ensure video is downloaded regardless of printing
         "-f",
         "webm[abr>0]/bestaudio/best", // select best quality audio-only


### PR DESCRIPTION
Closes #88.

## Decisions

When streaming to the terminal, download progress logs were also getting piped to stdout and then being consumed by Songbird and fed to ffmpeg. Using the `-q` flag in yt-dlp disables these messages.

![image](https://user-images.githubusercontent.com/5618493/156827757-ca868b24-273b-407b-aaf1-b06a4f5e26c8.png)

## Testing

I've only tested this fix on Windows, please @afonsojramos check whether this is now okay on your Linux machine. 🙂