### PR TITLE
chore: fix versions in cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ rspotify = "0.11.5"
 serde_json = "1.0.79"
 
 [dependencies.songbird]
-version = "0.2.1"
+version = "0.2.2"
 features = ["builtin-queue", "yt-dlp"]
 
 [dependencies.serenity]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,22 +9,22 @@ license = "MIT"
 keywords = ["discord", "music-bot", "rust"]
 
 [dependencies]
-dotenv = "0.15"
-lazy_static = "1.4"
-rand = "0.8"
-regex = "1.5"
-rspotify = "0.11"
-serde_json = "1.0"
+dotenv = "0.15.0"
+lazy_static = "1.4.0"
+rand = "0.8.5"
+regex = "1.5.5"
+rspotify = "0.11.5"
+serde_json = "1.0.79"
 
 [dependencies.songbird]
 version = "0.2.1"
 features = ["builtin-queue", "yt-dlp"]
 
 [dependencies.serenity]
-version = "0.10"
+version = "0.10.10"
 default-features = false
 features = ["cache", "collector", "client", "gateway", "model", "rustls_backend", "unstable_discord_api", "voice"]
 
 [dependencies.tokio]
-version = "1.17"
+version = "1.17.0"
 features = ["macros", "rt-multi-thread"]


### PR DESCRIPTION
We should ALWAYS lock patch versions in cargo.toml. 

Unless you can make sure that all the libraries that we depend on follow semver and that they won't introduce new features in a patch (spoiler alert, you can't - and we've actually done it more than once on our package because you don't want to bump the minor), then you should always lock the versions that you are using.

Please read more about this [here](https://users.rust-lang.org/t/psa-please-specify-precise-dependency-versions-in-cargo-toml/71277) or in another post related to this problem in any other language.