### PR TITLE
fix: bug label

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,6 +1,6 @@
 name: 🐛 Bug report
 description: Report errors or unexpected behavior for us to improve.
-labels: [🐛 bug, 👓 triage]
+labels: [🪲 bug, 👓 triage]
 body:
   - type: textarea
     attributes:


### PR DESCRIPTION
Also fixed the "👓 triage" label, because it was saved as `:eyeglasses:` instead of just the emoji, which would fail in the auto assign.