### PR TITLE
fix: make errors follow up messages

### DIFF
--- a/src/handlers/serenity.rs
+++ b/src/handlers/serenity.rs
@@ -8,7 +8,7 @@ use crate::{
     errors::ParrotError,
     handlers::track_end::update_queue_messages,
     sources::spotify::{Spotify, SPOTIFY},
-    utils::create_response_text,
+    utils::create_followup_text,
 };
 use serenity::{
     async_trait,
@@ -368,7 +368,7 @@ impl SerenityHandler {
         interaction: &mut ApplicationCommandInteraction,
         err: ParrotError,
     ) {
-        create_response_text(&ctx.http, interaction, &format!("{err}"))
+        create_followup_text(&ctx.http, interaction, &format!("{err}"))
             .await
             .expect("failed to create response");
     }

--- a/src/sources/youtube.rs
+++ b/src/sources/youtube.rs
@@ -187,7 +187,7 @@ async fn _ytdl_metadata(uri: &str) -> SongbirdResult<Metadata> {
     let o_vec = youtube_dl_output.stderr;
 
     // read until newline byte
-    let end = (&o_vec)
+    let end = (o_vec)
         .iter()
         .position(|el| *el == NEWLINE_BYTE)
         .unwrap_or(o_vec.len());

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -33,6 +33,16 @@ pub async fn create_response_text(
     create_embed_response(http, interaction, embed).await
 }
 
+pub async fn create_followup_text(
+    http: &Arc<Http>,
+    interaction: &mut ApplicationCommandInteraction,
+    content: &str,
+) -> Result<Message, ParrotError> {
+    let mut embed = CreateEmbed::default();
+    embed.description(content);
+    create_embed_followup(http, interaction, embed).await
+}
+
 pub async fn edit_response(
     http: &Arc<Http>,
     interaction: &mut ApplicationCommandInteraction,
@@ -64,6 +74,17 @@ pub async fn create_embed_response(
                 .kind(InteractionResponseType::ChannelMessageWithSource)
                 .interaction_response_data(|message| message.add_embed(embed))
         })
+        .await
+        .map_err(Into::into)
+}
+
+pub async fn create_embed_followup(
+    http: &Arc<Http>,
+    interaction: &mut ApplicationCommandInteraction,
+    embed: CreateEmbed,
+) -> Result<Message, ParrotError> {
+    interaction
+        .create_followup_message(&http, |followup| followup.add_embed(embed))
         .await
         .map_err(Into::into)
 }


### PR DESCRIPTION
Make errors follow up messages instead of responses so they do not collide with any other responses.

Resolves #201 