### PR TITLE
fix: address error logging regression

### DIFF
--- a/src/handlers/serenity.rs
+++ b/src/handlers/serenity.rs
@@ -8,7 +8,7 @@ use crate::{
     errors::ParrotError,
     handlers::track_end::update_queue_messages,
     sources::spotify::{Spotify, SPOTIFY},
-    utils::create_followup_text,
+    utils::create_response_text,
 };
 use serenity::{
     async_trait,
@@ -368,7 +368,7 @@ impl SerenityHandler {
         interaction: &mut ApplicationCommandInteraction,
         err: ParrotError,
     ) {
-        create_followup_text(&ctx.http, interaction, &format!("{err}"))
+        create_response_text(&ctx.http, interaction, &format!("{err}"))
             .await
             .expect("failed to create response");
     }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -68,14 +68,20 @@ pub async fn create_embed_response(
     interaction: &mut ApplicationCommandInteraction,
     embed: CreateEmbed,
 ) -> Result<(), ParrotError> {
-    interaction
+    let response: Result<(), ParrotError> = interaction
         .create_interaction_response(&http, |response| {
             response
                 .kind(InteractionResponseType::ChannelMessageWithSource)
-                .interaction_response_data(|message| message.add_embed(embed))
+                .interaction_response_data(|message| message.add_embed(embed.clone()))
         })
         .await
-        .map_err(Into::into)
+        .map_err(Into::into);
+    match response {
+        Ok(val) => Ok(val),
+        Err(..) => edit_embed_response(http, interaction, embed)
+            .await
+            .map(|_| ()),
+    }
 }
 
 pub async fn create_embed_followup(

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -33,16 +33,6 @@ pub async fn create_response_text(
     create_embed_response(http, interaction, embed).await
 }
 
-pub async fn create_followup_text(
-    http: &Arc<Http>,
-    interaction: &mut ApplicationCommandInteraction,
-    content: &str,
-) -> Result<Message, ParrotError> {
-    let mut embed = CreateEmbed::default();
-    embed.description(content);
-    create_embed_followup(http, interaction, embed).await
-}
-
 pub async fn edit_response(
     http: &Arc<Http>,
     interaction: &mut ApplicationCommandInteraction,
@@ -82,17 +72,6 @@ pub async fn create_embed_response(
             .await
             .map(|_| ()),
     }
-}
-
-pub async fn create_embed_followup(
-    http: &Arc<Http>,
-    interaction: &mut ApplicationCommandInteraction,
-    embed: CreateEmbed,
-) -> Result<Message, ParrotError> {
-    interaction
-        .create_followup_message(&http, |followup| followup.add_embed(embed))
-        .await
-        .map_err(Into::into)
 }
 
 pub async fn edit_embed_response(


### PR DESCRIPTION
Potential solution to #203

This makes create_embed_response clobber previous responses by default. I believe this approach is closer to intended behavior, but an alternative that some might like better is if instead of clobbering the original response it posts as a followup. Looking for feedback here.

I almost wish serenity bit the bullet here and tracked whether an interaction received a response locally. Unfortunately this was the nicest way to do this without adding another call to the discord api.