### PR TITLE
bump: serenity to 0.11.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1456,9 +1456,9 @@ dependencies = [
 
 [[package]]
 name = "serenity"
-version = "0.11.4"
+version = "0.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d1a6cef5e72d4e5787c96413ec0a45f9317c59f0099e2ff2038b73cb352fefd"
+checksum = "82fd5e7b5858ad96e99d440138f34f5b98e1b959ebcd3a1036203b30e78eb788"
 dependencies = [
  "async-trait",
  "async-tungstenite",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ version = "0.3.0"
 features = ["builtin-queue", "yt-dlp"]
 
 [dependencies.serenity]
-version = "0.11.4"
+version = "0.11.5"
 default-features = false
 features = ["cache", "collector", "client", "gateway", "model", "rustls_backend", "unstable_discord_api", "voice"]
 


### PR DESCRIPTION
[Serenity 0.11.5](https://github.com/serenity-rs/serenity/releases/tag/v0.11.5) was released back in July, no major changes.