### PR TITLE
fix: `/superplay next` with an empty queue throws ParrotError::NotInRange

### DIFF
--- a/src/commands/play.rs
+++ b/src/commands/play.rs
@@ -365,10 +365,10 @@ async fn insert_track(
     let queue_size = handler.queue().len();
     drop(handler);
 
-    verify(
-        idx != 0 && idx < queue_size,
-        ParrotError::NotInRange("index", idx as isize, 1, queue_size as isize),
-    )?;
+    if queue_size <= 1 {
+        let queue = enqueue_track(call, query_type).await?;
+        return Ok(queue);
+    }
 
     enqueue_track(call, query_type).await?;
 

--- a/src/commands/play.rs
+++ b/src/commands/play.rs
@@ -370,6 +370,11 @@ async fn insert_track(
         return Ok(queue);
     }
 
+    verify(
+        idx > 0 && idx <= queue_size,
+        ParrotError::NotInRange("index", idx as isize, 1, queue_size as isize),
+    )?;
+
     enqueue_track(call, query_type).await?;
 
     let handler = call.lock().await;


### PR DESCRIPTION
Resolves #207. Also removed the NotInRange check altogether as there's no real way it can fail.