### PR TITLE
ci: implement usage of stepped workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,7 @@
 name: Main Workflow
 
 on:
-  workflow_dispatch:
+  workflow_call:
 
 jobs:
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,13 +1,14 @@
 name: Main Workflow
 
-on: [push, pull_request]
+on:
+  workflow_dispatch:
 
 jobs:
   build:
     name: Build
     strategy:
       matrix:
-        rust-version: ["1.59", "stable"]
+        rust-version: ['1.59', 'stable']
     runs-on: ubuntu-latest
     steps:
       - name: Repository Checkout

--- a/.github/workflows/ci_workflow.yml
+++ b/.github/workflows/ci_workflow.yml
@@ -1,4 +1,4 @@
-name: CI Build
+name: CI Workflow
 
 on: [push, pull_request]
 

--- a/.github/workflows/ci_workflow.yml
+++ b/.github/workflows/ci_workflow.yml
@@ -1,0 +1,24 @@
+name: CI Build
+
+on: [push, pull_request]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build
+    uses: ./.github/workflows/build.yml
+    secrets: inherit
+
+  lint:
+    name: Lint
+    uses: ./.github/workflows/lint.yml
+    secrets: inherit
+
+  docker:
+    name: Docker
+    needs: [build, lint]
+    uses: ./.github/workflows/docker.yml
+    secrets: inherit

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -38,6 +38,6 @@ jobs:
         uses: docker/build-push-action@v3
         with:
           context: .
-          push: ${{ github.event_name == 'push' }}
+          push: ${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/') }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -4,7 +4,7 @@ on:
   push:
     tags: ['v*.*.*']
 
-  workflow_dispatch:
+  workflow_call:
 
 env:
   REGISTRY: ghcr.io

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -2,7 +2,7 @@ name: Docker Workflow
 on:
   push:
     branches: [main]
-    tags: ["v*.*.*"]
+    tags: ['v*.*.*']
   pull_request:
     branches: [main]
 env:
@@ -39,39 +39,3 @@ jobs:
           push: ${{ github.event_name == 'push' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-  deploy:
-    name: Development Team Deployment
-    needs: build
-    if: startsWith(github.ref, 'refs/tags/v')
-    runs-on: ubuntu-latest
-    steps:
-      - name: Deploy with New Image
-        uses: appleboy/ssh-action@master
-        with:
-          host: ${{ secrets.SSH_HOST }}
-          username: ${{ secrets.SSH_USER }}
-          key: ${{ secrets.SSH_KEY }}
-          script_stop: true
-          script: docker run -d --pull "always" --env-file .env ghcr.io/${{ github.repository }}:${{ github.ref_name }}
-      - name: Check New Image Status With Removal of Old Images
-        uses: appleboy/ssh-action@master
-        with:
-          host: ${{ secrets.SSH_HOST }}
-          username: ${{ secrets.SSH_USER }}
-          key: ${{ secrets.SSH_KEY }}
-          script_stop: true
-          script: if [ "$(docker ps | grep ghcr.io/${{ github.repository }}:${{ github.ref_name }})" ]; then docker kill $(docker ps -q | grep -v -E $(docker ps -aq --filter ancestor=ghcr.io/${{ github.repository }}:${{ github.ref_name }} | paste -sd "|" -));  fi
-      - name: Remove Exited Containers
-        uses: appleboy/ssh-action@master
-        with:
-          host: ${{ secrets.SSH_HOST }}
-          username: ${{ secrets.SSH_USER }}
-          key: ${{ secrets.SSH_KEY }}
-          script: docker rm $(docker ps --filter status=exited -q)
-      - name: Docker Prune
-        uses: appleboy/ssh-action@master
-        with:
-          host: ${{ secrets.SSH_HOST }}
-          username: ${{ secrets.SSH_USER }}
-          key: ${{ secrets.SSH_KEY }}
-          script: docker system prune -a -f

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,13 +1,15 @@
 name: Docker Workflow
+
 on:
   push:
-    branches: [main]
     tags: ['v*.*.*']
-  pull_request:
-    branches: [main]
+
+  workflow_dispatch:
+
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
+
 jobs:
   build:
     name: Build
@@ -33,7 +35,7 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
       - name: Build & Push Docker Image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           context: .
           push: ${{ github.event_name == 'push' }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -12,7 +12,7 @@ env:
 
 jobs:
   build:
-    name: Build
+    name: Build & Push Docker Image
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,6 +1,7 @@
 name: Lint
 
-on: [push, pull_request]
+on:
+  workflow_call:
 
 jobs:
   clippy:


### PR DESCRIPTION
This PR implements the usage of a stepped workflow as well as the feature of canceling a previous job in case a new commit comes in.

Additionally, to reduce the number of packages we are pushing, we are now limiting the push action to when it is either in main branch or a tag.

<img width="637" alt="image" src="https://user-images.githubusercontent.com/19473034/200429529-b063cddb-3650-4e61-9b55-32601bfe7ef4.png">

PS: @aquelemiguel Before merging this PR, we should update the required checks.

We currently have 110 untagged versions. Hopefully, with this, we'll reduce this number's growth drastically.

We may also consider using [delete-old-packages#ghcrio-packages](https://github.com/SmartsquareGmbH/delete-old-packages#ghcrio-packages) or something similar.