### PR TITLE
ci: keep Cargo.lock

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -12,4 +12,3 @@ README.md
 # Cargo files
 **/*.rs.bk
 /target/
-Cargo.lock

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,10 +11,11 @@ WORKDIR "/parrot"
 RUN mkdir src
 RUN echo "fn main() {}" > src/main.rs
 COPY Cargo.toml ./
-RUN cargo build --release
+COPY Cargo.lock ./
+RUN cargo build --release --locked
 
 COPY . .
-RUN cargo build --release
+RUN cargo build --release --locked
 
 # Release image
 # Necessary dependencies to run Parrot


### PR DESCRIPTION
Fixes the actual reason that caused #227, which was having the dependencies lock in the `.dockerignore`. Also adds some small QoL changes like forcing cargo to use the locked dependencies, fixing the Rust Docker image version and adding a compose file.