### PR TITLE
feat: add guild settings de/serialization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /target/
 
+/data/
+
 .env
-prefixes.json

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -987,6 +987,7 @@ dependencies = [
  "rand",
  "regex",
  "rspotify",
+ "serde",
  "serde_json",
  "serenity",
  "songbird",
@@ -1084,9 +1085,9 @@ checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.42"
+version = "1.0.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c278e965f1d8cf32d6e0e96de3d3e79712178ae67986d9cf9151f51e95aac89b"
+checksum = "5d727cae5b39d21da60fa540906919ad737832fe0b1c165da3a34d6548c849d6"
 dependencies = [
  "unicode-ident",
 ]
@@ -1398,9 +1399,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.140"
+version = "1.0.152"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc855a42c7967b7c369eb5860f7164ef1f6f81c20c7cc1141f2a604e18723b03"
+checksum = "bb7d1f0d3021d347a83e556fc4683dea2ea09d87bccdf88ff5c12545d89d5efb"
 dependencies = [
  "serde_derive",
 ]
@@ -1417,9 +1418,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.140"
+version = "1.0.152"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f2122636b9fe3b81f1cb25099fcf2d3f542cdb1d45940d56c713158884a05da"
+checksum = "af487d118eecd09402d70a5d72551860e788df87b464af30e5ea6a38c75c541e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1671,9 +1672,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.98"
+version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c50aef8a904de4c23c788f104b7dddc7d6f79c647c7c8ce4cc8f73eb0ca773dd"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ regex = "1.5.5"
 rspotify = "0.11.6"
 serde_json = "1.0.79"
 url = "2.3.1"
+serde = "1.0.152"
 
 [dependencies.songbird]
 version = "0.3.0"

--- a/src/commands/autopause.rs
+++ b/src/commands/autopause.rs
@@ -1,5 +1,7 @@
 use crate::{
-    errors::ParrotError, guild::settings::GuildSettingsMap, messaging::message::ParrotMessage,
+    errors::ParrotError,
+    guild::settings::{GuildSettings, GuildSettingsMap},
+    messaging::message::ParrotMessage,
     utils::create_response,
 };
 use serenity::{
@@ -15,7 +17,9 @@ pub async fn autopause(
     let mut data = ctx.data.write().await;
     let settings = data.get_mut::<GuildSettingsMap>().unwrap();
 
-    let guild_settings = settings.entry(guild_id).or_default();
+    let guild_settings = settings
+        .entry(guild_id)
+        .or_insert(GuildSettings::new(guild_id));
     guild_settings.toggle_autopause();
     guild_settings.save()?;
 

--- a/src/commands/autopause.rs
+++ b/src/commands/autopause.rs
@@ -19,7 +19,7 @@ pub async fn autopause(
 
     let guild_settings = settings
         .entry(guild_id)
-        .or_insert(GuildSettings::new(guild_id));
+        .or_insert_with(|| GuildSettings::new(guild_id));
     guild_settings.toggle_autopause();
     guild_settings.save()?;
 

--- a/src/commands/autopause.rs
+++ b/src/commands/autopause.rs
@@ -16,7 +16,8 @@ pub async fn autopause(
     let settings = data.get_mut::<GuildSettingsMap>().unwrap();
 
     let guild_settings = settings.entry(guild_id).or_default();
-    guild_settings.autopause = !guild_settings.autopause;
+    guild_settings.toggle_autopause();
+    guild_settings.save()?;
 
     if guild_settings.autopause {
         create_response(&ctx.http, interaction, ParrotMessage::AutopauseOn).await

--- a/src/commands/manage_sources.rs
+++ b/src/commands/manage_sources.rs
@@ -1,6 +1,6 @@
 use crate::{
     errors::ParrotError,
-    guild::settings::GuildSettingsMap,
+    guild::settings::{GuildSettings, GuildSettingsMap},
     messaging::messages::{
         DOMAIN_FORM_ALLOWED_PLACEHOLDER, DOMAIN_FORM_ALLOWED_TITLE, DOMAIN_FORM_BANNED_PLACEHOLDER,
         DOMAIN_FORM_BANNED_TITLE, DOMAIN_FORM_TITLE,
@@ -29,7 +29,9 @@ pub async fn allow(
     let mut data = ctx.data.write().await;
     let settings = data.get_mut::<GuildSettingsMap>().unwrap();
 
-    let guild_settings = settings.entry(guild_id).or_default();
+    let guild_settings = settings
+        .entry(guild_id)
+        .or_insert(GuildSettings::new(guild_id));
 
     // transform the domain sets from the settings into a string
     let allowed_str = guild_settings

--- a/src/commands/manage_sources.rs
+++ b/src/commands/manage_sources.rs
@@ -31,7 +31,7 @@ pub async fn allow(
 
     let guild_settings = settings
         .entry(guild_id)
-        .or_insert(GuildSettings::new(guild_id));
+        .or_insert_with(|| GuildSettings::new(guild_id));
 
     // transform the domain sets from the settings into a string
     let allowed_str = guild_settings

--- a/src/commands/manage_sources.rs
+++ b/src/commands/manage_sources.rs
@@ -114,6 +114,7 @@ pub async fn allow(
             }
 
             guild_settings.update_domains();
+            guild_settings.save().unwrap();
 
             // it's now safe to close the modal, so send a response to it
             int.create_interaction_response(&ctx.http, |r| {

--- a/src/commands/play.rs
+++ b/src/commands/play.rs
@@ -76,7 +76,7 @@ pub async fn play(
     let manager = songbird::get(ctx).await.unwrap();
 
     // try to join a voice channel if not in one just yet
-    summon(ctx, interaction, false).await?;
+    summon(ctx, interaction, false, false).await?;
     let call = manager.get(guild_id).unwrap();
 
     // determine whether this is a link or a query string

--- a/src/commands/play.rs
+++ b/src/commands/play.rs
@@ -1,7 +1,7 @@
 use crate::{
     commands::{skip::force_skip_top_track, summon::summon},
     errors::{verify, ParrotError},
-    guild::settings::GuildSettingsMap,
+    guild::settings::{GuildSettings, GuildSettingsMap},
     handlers::track_end::update_queue_messages,
     messaging::message::ParrotMessage,
     messaging::messages::{
@@ -90,7 +90,9 @@ pub async fn play(
             Some(other) => {
                 let mut data = ctx.data.write().await;
                 let settings = data.get_mut::<GuildSettingsMap>().unwrap();
-                let guild_settings = settings.entry(guild_id).or_default();
+                let guild_settings = settings
+                    .entry(guild_id)
+                    .or_insert(GuildSettings::new(guild_id));
 
                 let is_allowed = guild_settings
                     .allowed_domains
@@ -120,7 +122,9 @@ pub async fn play(
         Err(_) => {
             let mut data = ctx.data.write().await;
             let settings = data.get_mut::<GuildSettingsMap>().unwrap();
-            let guild_settings = settings.entry(guild_id).or_default();
+            let guild_settings = settings
+                .entry(guild_id)
+                .or_insert(GuildSettings::new(guild_id));
 
             if guild_settings.banned_domains.contains("youtube.com")
                 || (guild_settings.banned_domains.is_empty()

--- a/src/commands/play.rs
+++ b/src/commands/play.rs
@@ -92,7 +92,7 @@ pub async fn play(
                 let settings = data.get_mut::<GuildSettingsMap>().unwrap();
                 let guild_settings = settings
                     .entry(guild_id)
-                    .or_insert(GuildSettings::new(guild_id));
+                    .or_insert_with(|| GuildSettings::new(guild_id));
 
                 let is_allowed = guild_settings
                     .allowed_domains
@@ -124,7 +124,7 @@ pub async fn play(
             let settings = data.get_mut::<GuildSettingsMap>().unwrap();
             let guild_settings = settings
                 .entry(guild_id)
-                .or_insert(GuildSettings::new(guild_id));
+                .or_insert_with(|| GuildSettings::new(guild_id));
 
             if guild_settings.banned_domains.contains("youtube.com")
                 || (guild_settings.banned_domains.is_empty()

--- a/src/commands/play.rs
+++ b/src/commands/play.rs
@@ -76,7 +76,7 @@ pub async fn play(
     let manager = songbird::get(ctx).await.unwrap();
 
     // try to join a voice channel if not in one just yet
-    summon(ctx, interaction, false, false).await?;
+    summon(ctx, interaction, false).await?;
     let call = manager.get(guild_id).unwrap();
 
     // determine whether this is a link or a query string

--- a/src/commands/summon.rs
+++ b/src/commands/summon.rs
@@ -72,10 +72,12 @@ pub async fn summon(
 
     // load existing guild settings to memory
     if load_settings && Path::new("test.json").exists() {
-        let guild_settings = GuildSettings::from_file("test.json")?;
         let mut data = ctx.data.write().await;
         let settings = data.get_mut::<GuildSettingsMap>().unwrap();
-        settings.insert(guild_id, guild_settings);
+        let guild_settings = settings
+            .entry(guild_id)
+            .or_insert(GuildSettings::new(guild_id));
+        guild_settings.load()?;
     }
 
     if send_reply {

--- a/src/commands/summon.rs
+++ b/src/commands/summon.rs
@@ -1,6 +1,7 @@
 use crate::{
     connection::get_voice_channel_for_user,
     errors::ParrotError,
+    guild::settings::{GuildSettings, GuildSettingsMap},
     handlers::{IdleHandler, TrackEndHandler},
     messaging::message::ParrotMessage,
     utils::create_response,
@@ -13,12 +14,13 @@ use serenity::{
     prelude::Mentionable,
 };
 use songbird::{Event, TrackEvent};
-use std::time::Duration;
+use std::{path::Path, time::Duration};
 
 pub async fn summon(
     ctx: &Context,
     interaction: &mut ApplicationCommandInteraction,
     send_reply: bool,
+    load_settings: bool,
 ) -> Result<(), ParrotError> {
     let guild_id = interaction.guild_id.unwrap();
     let guild = ctx.cache.guild(guild_id).unwrap();
@@ -66,6 +68,14 @@ pub async fn summon(
                 ctx_data: ctx.data.clone(),
             },
         );
+    }
+
+    // load existing guild settings to memory
+    if load_settings && Path::new("test.json").exists() {
+        let guild_settings = GuildSettings::from_file("test.json")?;
+        let mut data = ctx.data.write().await;
+        let settings = data.get_mut::<GuildSettingsMap>().unwrap();
+        settings.insert(guild_id, guild_settings);
     }
 
     if send_reply {

--- a/src/commands/summon.rs
+++ b/src/commands/summon.rs
@@ -14,7 +14,7 @@ use serenity::{
     prelude::Mentionable,
 };
 use songbird::{Event, TrackEvent};
-use std::{path::Path, time::Duration};
+use std::time::Duration;
 
 pub async fn summon(
     ctx: &Context,

--- a/src/commands/summon.rs
+++ b/src/commands/summon.rs
@@ -71,13 +71,13 @@ pub async fn summon(
     }
 
     // load existing guild settings to memory
-    if load_settings && Path::new("test.json").exists() {
+    if load_settings {
         let mut data = ctx.data.write().await;
         let settings = data.get_mut::<GuildSettingsMap>().unwrap();
         let guild_settings = settings
             .entry(guild_id)
             .or_insert(GuildSettings::new(guild_id));
-        guild_settings.load()?;
+        guild_settings.load_if_exists()?;
     }
 
     if send_reply {

--- a/src/commands/summon.rs
+++ b/src/commands/summon.rs
@@ -1,7 +1,6 @@
 use crate::{
     connection::get_voice_channel_for_user,
     errors::ParrotError,
-    guild::settings::{GuildSettings, GuildSettingsMap},
     handlers::{IdleHandler, TrackEndHandler},
     messaging::message::ParrotMessage,
     utils::create_response,
@@ -20,7 +19,6 @@ pub async fn summon(
     ctx: &Context,
     interaction: &mut ApplicationCommandInteraction,
     send_reply: bool,
-    load_settings: bool,
 ) -> Result<(), ParrotError> {
     let guild_id = interaction.guild_id.unwrap();
     let guild = ctx.cache.guild(guild_id).unwrap();
@@ -68,16 +66,6 @@ pub async fn summon(
                 ctx_data: ctx.data.clone(),
             },
         );
-    }
-
-    // load existing guild settings to memory
-    if load_settings {
-        let mut data = ctx.data.write().await;
-        let settings = data.get_mut::<GuildSettingsMap>().unwrap();
-        let guild_settings = settings
-            .entry(guild_id)
-            .or_insert_with(|| GuildSettings::new(guild_id));
-        guild_settings.load_if_exists()?;
     }
 
     if send_reply {

--- a/src/commands/summon.rs
+++ b/src/commands/summon.rs
@@ -76,7 +76,7 @@ pub async fn summon(
         let settings = data.get_mut::<GuildSettingsMap>().unwrap();
         let guild_settings = settings
             .entry(guild_id)
-            .or_insert(GuildSettings::new(guild_id));
+            .or_insert_with(|| GuildSettings::new(guild_id));
         guild_settings.load_if_exists()?;
     }
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -24,6 +24,8 @@ pub enum ParrotError {
     AlreadyConnected(Mention),
     Serenity(SerenityError),
     RSpotify(RSpotifyClientError),
+    IO(std::io::Error),
+    Serde(serde_json::Error),
 }
 
 /// `ParrotError` implements the [`Debug`] and [`Display`] traits
@@ -66,6 +68,8 @@ impl Display for ParrotError {
             },
             Self::Serenity(err) => f.write_str(&format!("{err}")),
             Self::RSpotify(err) => f.write_str(&format!("{err}")),
+            Self::IO(err) => f.write_str(&format!("{err}")),
+            Self::Serde(err) => f.write_str(&format!("{err}")),
         }
     }
 }
@@ -89,6 +93,20 @@ impl PartialEq for ParrotError {
             (Self::Serenity(l0), Self::Serenity(r0)) => format!("{l0:?}") == format!("{r0:?}"),
             _ => core::mem::discriminant(self) == core::mem::discriminant(other),
         }
+    }
+}
+
+/// Provides an implementation to convert a [`std::io::Error`] to a [`ParrotError`].
+impl From<std::io::Error> for ParrotError {
+    fn from(err: std::io::Error) -> Self {
+        Self::IO(err)
+    }
+}
+
+/// Provides an implementation to convert a [`serde_json::Error`] to a [`ParrotError`].
+impl From<serde_json::Error> for ParrotError {
+    fn from(err: serde_json::Error) -> Self {
+        Self::Serde(err)
     }
 }
 

--- a/src/guild/settings.rs
+++ b/src/guild/settings.rs
@@ -19,7 +19,7 @@ lazy_static! {
         env::var("SETTINGS_PATH").unwrap_or(DEFAULT_SETTINGS_PATH.to_string());
 }
 
-#[derive(Clone, Deserialize, Serialize)]
+#[derive(Deserialize, Serialize)]
 pub struct GuildSettings {
     pub guild_id: GuildId,
     pub autopause: bool,

--- a/src/guild/settings.rs
+++ b/src/guild/settings.rs
@@ -61,7 +61,13 @@ impl GuildSettings {
     pub fn save(&self) -> Result<(), ParrotError> {
         create_dir_all(SETTINGS_PATH.as_str())?;
         let path = format!("{}/{}.json", SETTINGS_PATH.as_str(), self.guild_id);
-        let file = OpenOptions::new().write(true).truncate(true).create(true).open(path)?;
+
+        let file = OpenOptions::new()
+            .write(true)
+            .truncate(true)
+            .create(true)
+            .open(path)?;
+
         let writer = BufWriter::new(file);
         serde_json::to_writer(writer, self)?;
         Ok(())

--- a/src/guild/settings.rs
+++ b/src/guild/settings.rs
@@ -10,7 +10,7 @@ use serenity::{model::id::GuildId, prelude::TypeMapKey};
 
 use crate::errors::ParrotError;
 
-const SETTINGS_PATH: &str = "data/settings";
+const DEFAULT_SETTINGS_PATH: &str = "data/settings";
 const DEFAULT_ALLOWED_DOMAINS: [&str; 1] = ["youtube.com"];
 
 #[derive(Clone, Deserialize, Serialize)]
@@ -37,7 +37,7 @@ impl GuildSettings {
     }
 
     pub fn load_if_exists(&mut self) -> Result<(), ParrotError> {
-        let path = format!("{}/{}.json", SETTINGS_PATH, self.guild_id);
+        let path = format!("{}/{}.json", DEFAULT_SETTINGS_PATH, self.guild_id);
         if !Path::new(&path).exists() {
             return Ok(());
         }
@@ -45,7 +45,7 @@ impl GuildSettings {
     }
 
     pub fn load(&mut self) -> Result<(), ParrotError> {
-        let path = format!("{}/{}.json", SETTINGS_PATH, self.guild_id);
+        let path = format!("{}/{}.json", DEFAULT_SETTINGS_PATH, self.guild_id);
         let file = OpenOptions::new().read(true).open(path)?;
         let reader = BufReader::new(file);
         *self = serde_json::from_reader::<_, GuildSettings>(reader)?;
@@ -53,8 +53,8 @@ impl GuildSettings {
     }
 
     pub fn save(&self) -> Result<(), ParrotError> {
-        create_dir_all(SETTINGS_PATH)?;
-        let path = format!("{}/{}.json", SETTINGS_PATH, self.guild_id);
+        create_dir_all(DEFAULT_SETTINGS_PATH)?;
+        let path = format!("{}/{}.json", DEFAULT_SETTINGS_PATH, self.guild_id);
         let file = OpenOptions::new().write(true).create(true).open(path)?;
         let writer = BufWriter::new(file);
         serde_json::to_writer(writer, self)?;

--- a/src/guild/settings.rs
+++ b/src/guild/settings.rs
@@ -41,11 +41,16 @@ impl GuildSettings {
         Ok(guild_settings)
     }
 
-    pub fn save(&self, path: &str) -> Result<(), ParrotError> {
+    pub fn save(&self) -> Result<(), ParrotError> {
+        let path = "test.json";
         let file = File::create(path)?;
         let writer = BufWriter::new(file);
         serde_json::to_writer(writer, self)?;
         Ok(())
+    }
+
+    pub fn toggle_autopause(&mut self) {
+        self.autopause = !self.autopause;
     }
 
     pub fn set_allowed_domains(&mut self, allowed_str: &str) {

--- a/src/guild/settings.rs
+++ b/src/guild/settings.rs
@@ -61,7 +61,7 @@ impl GuildSettings {
     pub fn save(&self) -> Result<(), ParrotError> {
         create_dir_all(SETTINGS_PATH.as_str())?;
         let path = format!("{}/{}.json", SETTINGS_PATH.as_str(), self.guild_id);
-        let file = OpenOptions::new().write(true).create(true).open(path)?;
+        let file = OpenOptions::new().write(true).truncate(true).create(true).open(path)?;
         let writer = BufWriter::new(file);
         serde_json::to_writer(writer, self)?;
         Ok(())

--- a/src/handlers/serenity.rs
+++ b/src/handlers/serenity.rs
@@ -350,7 +350,7 @@ impl SerenityHandler {
             "shuffle" => shuffle(ctx, command).await,
             "skip" => skip(ctx, command).await,
             "stop" => stop(ctx, command).await,
-            "summon" => summon(ctx, command, true).await,
+            "summon" => summon(ctx, command, true, true).await,
             "version" => version(ctx, command).await,
             "voteskip" => voteskip(ctx, command).await,
             _ => unreachable!(),

--- a/src/handlers/serenity.rs
+++ b/src/handlers/serenity.rs
@@ -279,21 +279,21 @@ impl SerenityHandler {
     }
 
     async fn load_guilds_settings(&self, ctx: &Context, ready: &Ready) {
+        println!("[INFO] Loading guilds' settings");
         let mut data = ctx.data.write().await;
         for guild in &ready.guilds {
-            if !guild.unavailable {
-                let settings = data.get_mut::<GuildSettingsMap>().unwrap();
+            println!("[DEBUG] Loading guild settings for {:?}", guild);
+            let settings = data.get_mut::<GuildSettingsMap>().unwrap();
 
-                let guild_settings = settings
-                    .entry(guild.id)
-                    .or_insert_with(|| GuildSettings::new(guild.id));
+            let guild_settings = settings
+                .entry(guild.id)
+                .or_insert_with(|| GuildSettings::new(guild.id));
 
-                if let Err(err) = guild_settings.load_if_exists() {
-                    println!(
-                        "[ERROR] Failed to load guild {} settings due to {}",
-                        guild.id, err
-                    );
-                }
+            if let Err(err) = guild_settings.load_if_exists() {
+                println!(
+                    "[ERROR] Failed to load guild {} settings due to {}",
+                    guild.id, err
+                );
             }
         }
     }


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | https://github.com/aquelemiguel/parrot/issues/124 |
| Dependencies | Add `serde` crate. |
| Decisions | Derive Serialize and Deserialize traits for the GuildSettings struct. Implement a save() and load() methods. Load when the bot is summoned. Save whenever a setting changes. Save parrot data to /data/ and settings to /data/settings. |
