### PR TITLE
Enqueuing playlists: skip songs that cannot be added

### DIFF
--- a/src/commands/play.rs
+++ b/src/commands/play.rs
@@ -169,8 +169,9 @@ pub async fn play(
                     .ok_or(ParrotError::Other("failed to fetch playlist"))?;
 
                 for url in urls.iter() {
-                    let queue =
-                        enqueue_track(&call, &QueryType::VideoLink(url.to_string())).await?;
+                    let Ok(queue) = enqueue_track(&call, &QueryType::VideoLink(url.to_string())).await else {
+                        continue;
+                    };
                     update_queue_messages(&ctx.http, &ctx.data, &queue, guild_id).await;
                 }
             }
@@ -193,7 +194,9 @@ pub async fn play(
                     .ok_or(ParrotError::Other("failed to fetch playlist"))?;
 
                 for (idx, url) in urls.into_iter().enumerate() {
-                    let queue = insert_track(&call, &QueryType::VideoLink(url), idx + 1).await?;
+                    let Ok(queue) = insert_track(&call, &QueryType::VideoLink(url), idx + 1).await else {
+                        continue;
+                    };
                     update_queue_messages(&ctx.http, &ctx.data, &queue, guild_id).await;
                 }
             }
@@ -224,8 +227,9 @@ pub async fn play(
                 let mut insert_idx = 1;
 
                 for (i, url) in urls.into_iter().enumerate() {
-                    let mut queue =
-                        insert_track(&call, &QueryType::VideoLink(url), insert_idx).await?;
+                    let Ok(mut queue) = insert_track(&call, &QueryType::VideoLink(url), insert_idx).await else {
+                        continue;
+                    };
 
                     if i == 0 && !queue_was_empty {
                         queue = force_skip_top_track(&call.lock().await).await?;
@@ -260,7 +264,9 @@ pub async fn play(
                     .ok_or(ParrotError::Other("failed to fetch playlist"))?;
 
                 for url in urls.into_iter() {
-                    let queue = enqueue_track(&call, &QueryType::VideoLink(url)).await?;
+                    let Ok(queue) = enqueue_track(&call, &QueryType::VideoLink(url)).await else {
+                        continue;
+                    };
                     update_queue_messages(&ctx.http, &ctx.data, &queue, guild_id).await;
                 }
             }

--- a/src/sources/youtube.rs
+++ b/src/sources/youtube.rs
@@ -23,7 +23,7 @@ pub struct YouTube {}
 
 impl YouTube {
     pub fn extract(query: &str) -> Option<QueryType> {
-        if query.contains("playlist?list=") {
+        if query.contains("list=") {
             Some(QueryType::PlaylistLink(query.to_string()))
         } else {
             Some(QueryType::VideoLink(query.to_string()))


### PR DESCRIPTION
This pull request changes the behaviour when enqueuing playlists. If there is a problem while enqueuing a track of a playlist the problematic song is skipped instead of canceling the whole process.
Also the mask for playlists in the YouTube::extract function was changed to match more playlist links.