### PR TITLE
fix: ignore yt-dlp warnings

### DIFF
--- a/src/sources/youtube.rs
+++ b/src/sources/youtube.rs
@@ -124,6 +124,7 @@ async fn ytdl(uri: &str) -> Result<(Child, Metadata), SongbirdError> {
         "infinite",        // infinite number of download retries
         "--no-playlist",   // only download the video if URL also has playlist info
         "--ignore-config", // disable all configuration files for a yt-dlp run
+        "--no-warnings",   // don't print out warnings
         uri,
         "-o",
         "-", // stream data to stdout
@@ -173,6 +174,7 @@ async fn _ytdl_metadata(uri: &str) -> SongbirdResult<Metadata> {
         "infinite",        // infinite number of download retries
         "--no-playlist",   // only download the video if URL also has playlist info
         "--ignore-config", // disable all configuration files for a yt-dlp run
+        "--no-warnings",   // don't print out warnings
         uri,
         "-o",
         "-", // stream data to stdout


### PR DESCRIPTION
The warnings interfere with JSON parsing

Fixes #242