### PR TITLE
ci: update actions/checkout to v4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Repository Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Install Toolchain
         uses: actions-rs/toolchain@v1

--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install Toolchain
         uses: actions-rs/toolchain@v1

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -19,7 +19,7 @@ jobs:
       packages: write
     steps:
       - name: Repository Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Registry Login
         uses: docker/login-action@v1

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,7 +10,7 @@ jobs:
 
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Install stable toolchain
         id: toolchain
@@ -36,7 +36,7 @@ jobs:
 
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Install stable toolchain
         uses: actions-rs/toolchain@v1


### PR DESCRIPTION
## Summary
- Update `actions/checkout` from v2/v3 to v4 across all workflow files
- v4 uses Node 20 instead of deprecated Node 16

## Files changed
- `.github/workflows/build.yml`
- `.github/workflows/bump.yml`
- `.github/workflows/docker.yml`
- `.github/workflows/lint.yml`