### PR TITLE
ci: update Swatinem/rust-cache to v2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
           override: true
 
       - name: Cache
-        uses: Swatinem/rust-cache@v1
+        uses: Swatinem/rust-cache@v2
 
       - name: Build Binary
         run: cargo build --locked

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -22,7 +22,7 @@ jobs:
           override: true
 
       - name: Cache
-        uses: Swatinem/rust-cache@v1
+        uses: Swatinem/rust-cache@v2
 
       - name: Run clippy
         uses: actions-rs/clippy-check@v1


### PR DESCRIPTION
## Summary
- Update `Swatinem/rust-cache` from v1 to v2
- v2 includes improved caching strategies and bug fixes

## Files changed
- `.github/workflows/build.yml`
- `.github/workflows/lint.yml`