### PR TITLE
ci: replace actions-rs/toolchain with dtolnay/rust-toolchain

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,11 +15,9 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Install Toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.rust-version }}
-          profile: minimal
-          override: true
 
       - name: Cache
         uses: Swatinem/rust-cache@v1

--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -21,11 +21,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install Toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          profile: minimal
-          override: true
+        uses: dtolnay/rust-toolchain@stable
 
       - name: Install cargo-bump
         run: cargo install cargo-bump

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,13 +13,9 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Install stable toolchain
-        id: toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: stable
           components: clippy
-          profile: minimal
-          override: true
 
       - name: Cache
         uses: Swatinem/rust-cache@v1
@@ -39,12 +35,9 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Install stable toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: stable
           components: rustfmt
-          profile: minimal
-          override: true
 
       - name: Run cargo fmt
         run: cargo fmt --all -- --check


### PR DESCRIPTION
## Summary
- Replace deprecated `actions-rs/toolchain` with `dtolnay/rust-toolchain`
- The `actions-rs` organization is archived and unmaintained
- `dtolnay/rust-toolchain` is the recommended replacement

## Files changed
- `.github/workflows/build.yml`
- `.github/workflows/bump.yml`
- `.github/workflows/lint.yml`