### PR TITLE
ci: replace actions-rs/clippy-check with cargo clippy

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -25,10 +25,7 @@ jobs:
         uses: Swatinem/rust-cache@v1
 
       - name: Run clippy
-        uses: actions-rs/clippy-check@v1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          args: -- -D clippy::all -D warnings
+        run: cargo clippy -- -D clippy::all -D warnings
 
   rustfmt:
     name: Format


### PR DESCRIPTION
## Summary
- Replace deprecated `actions-rs/clippy-check` with direct `cargo clippy` command
- The `actions-rs` organization is archived and unmaintained
- Direct cargo commands are simpler and don't require external actions

## Files changed
- `.github/workflows/lint.yml`